### PR TITLE
Rebuild Delay on Tone.FeedbackDelay instead of a hand-rolled dry/wet composite

### DIFF
--- a/src/audio/nodes/delay.ts
+++ b/src/audio/nodes/delay.ts
@@ -1,44 +1,35 @@
-import { Delay, Gain } from 'tone';
+import { FeedbackDelay } from 'tone';
 import { _audioNodes } from '../audioCore';
 import type { NodeTypeHandler } from './nodeHandler';
 import type { DelayNodeData } from '../../store/dawTypes';
+
+// "Delay" is a FeedbackDelay with the repeat path permanently disabled
+// (feedback pinned to 0, never exposed to setAudioParam) — gets Effect's
+// equal-power wet/dry CrossFade for free instead of hand-rolling one.
 
 export const delayHandler: NodeTypeHandler<DelayNodeData> = {
 	defaultData: { label: 'Delay', delayTime: 0.25, wet: 1 },
 
 	create(id, data) {
-		const wet      = data.wet ?? 1;
-		const _delay   = new Delay(data.delayTime);
-		const _dryGain = new Gain(1 - wet);
-		const _wetGain = new Gain(wet);
-		const input    = new Gain(1);
-		const output   = new Gain(1);
-		input.connect(_dryGain);
-		input.connect(_delay);
-		_delay.connect(_wetGain);
-		_dryGain.connect(output);
-		_wetGain.connect(output);
-		_audioNodes.set(id, { kind: 'delay', toneNode: { input, output }, _delay, _dryGain, _wetGain });
+		const toneNode = new FeedbackDelay({
+			delayTime: data.delayTime ?? 0.25,
+			feedback:  0,
+			wet:       data.wet ?? 1,
+		});
+		_audioNodes.set(id, { kind: 'delay', toneNode });
 	},
 
 	dispose(id) {
 		const e = _audioNodes.get(id);
 		if (e?.kind !== 'delay') return;
-		e.toneNode.input.dispose();
-		e.toneNode.output.dispose();
-		e._delay.dispose();
-		e._dryGain.dispose();
-		e._wetGain.dispose();
+		e.toneNode.dispose();
 		_audioNodes.delete(id);
 	},
 
 	setAudioParam(id, update) {
 		const e = _audioNodes.get(id);
 		if (e?.kind !== 'delay') return;
-		if (update.delayTime !== undefined) e._delay.delayTime.value = update.delayTime;
-		if (update.wet       !== undefined) {
-			e._wetGain.gain.value = update.wet;
-			e._dryGain.gain.value = 1 - update.wet;
-		}
+		if (update.delayTime !== undefined) e.toneNode.delayTime.value = update.delayTime;
+		if (update.wet       !== undefined) e.toneNode.wet.value       = update.wet;
 	},
 };

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, Delay, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -477,7 +477,7 @@ export type SceneInputAudioEntry = {
 export type ReverbAudioEntry          = { kind: 'reverb';           toneNode: Reverb };
 export type JCReverbAudioEntry        = { kind: 'jcReverb';         toneNode: JCReverb };
 export type FreeverbAudioEntry        = { kind: 'freeverb';         toneNode: Freeverb };
-export type DelayAudioEntry           = { kind: 'delay'; toneNode: { input: Gain; output: Gain }; _delay: Delay; _dryGain: Gain; _wetGain: Gain };
+export type DelayAudioEntry           = { kind: 'delay';             toneNode: FeedbackDelay };
 export type FeedbackDelayAudioEntry   = { kind: 'feedbackDelay';    toneNode: FeedbackDelay };
 export type PingPongDelayAudioEntry   = { kind: 'pingPongDelay';    toneNode: PingPongDelay };
 export type DistortionAudioEntry      = { kind: 'distortion';       toneNode: Distortion };


### PR DESCRIPTION
## Summary
- `delay.ts` hand-built a wet/dry mix (two `Gain`s, linear crossfade) wrapped around a bare `Tone.Delay`, stored as `toneNode: { input: Gain; output: Gain }` — a plain object, not a real `ToneAudioNode`. It has no `.connect()` method, so `audioCore.ts`'s routing only worked by accident: the manual chain-walk helpers (`_resolveInput`/`_resolveOutput`) duck-type on `.output !== undefined` rather than checking `instanceof ToneAudioNode`.
- `Tone.FeedbackDelay` (already used for the `'feedbackDelay'` kind) extends `Effect`, which provides the identical input → wet/dry → output topology for free — via an equal-power `CrossFade`, not a hand-rolled linear one, matching every other effect node in this app instead of being the one inconsistent case.
- Pinning `feedback` to `0` at construction and never exposing it in `setAudioParam` (`DelayNodeData` has no `feedback` field) reproduces the single-tap delay behavior "Delay" already promises.
- `DelayAudioEntry` now holds a real `toneNode: FeedbackDelay` — one object instead of five (`toneNode`, `_delay`, `_dryGain`, `_wetGain`, plus the fake `input`/`output` composite), matching the shape of every other effect entry (`ReverbAudioEntry`, `ChorusAudioEntry`, etc.).
- Net: -25/+16 lines, one fewer special-shaped `AudioNodeEntry`.

Found while reviewing `delay.ts` against the installed Tone.js source (`node_modules/tone`, v15.1.22) as part of a broader look at deepening the audio routing layer.

## Test plan
- [x] `tsc --noEmit` — no new errors (10 pre-existing errors remain, all in unrelated files)
- [x] `eslint` on both touched files — clean
- [x] `pnpm run build` — succeeds
- [x] Manual verification in the running app: added a Delay node, wired Scene Input X → Delay → Master Output Y, started the scene. Scope renders a live woven crosshatch pattern (delayed signal against the direct one) with default `time=0.25s, wet=1.0` params — confirms `create()`, `setAudioParam`, and routing all work end-to-end. Zero console errors throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)