### PR TITLE
Track Player position against the AudioContext clock, not Tone.Transport

### DIFF
--- a/src/audio/nodes/player.ts
+++ b/src/audio/nodes/player.ts
@@ -1,14 +1,18 @@
-import { Player, Split, getTransport, start as toneStart } from 'tone';
-import { _audioNodes } from '../audioCore';
+import { Player, Split, start as toneStart } from 'tone';
+import { _audioNodes, getAudioCurrentTime } from '../audioCore';
 import type { NodeTypeHandler } from './nodeHandler';
 import type { PlayerNodeData, PlayerAudioEntry } from '../../store/dawTypes';
 
 // ─── Player node ──────────────────────────────────────────────────────────────
-// Playback is transport-coupled: position is derived from the Tone transport
-// clock (startOffset + transport.seconds * rate), so play/pause/seek/rate all
-// have to stop and restart the transport in lockstep with the Player. Those
-// operations live here as the player module's own interface; the handler covers
-// the shared lifecycle protocol (create/dispose).
+// Position is tracked against the AudioContext's own clock (startOffset +
+// elapsed-since-startedAt * rate) — not Tone.Transport. Transport is a global
+// singleton; an earlier version of this module used it as a shared stopwatch,
+// which meant starting/seeking one Player node reset the position readout of
+// every other Player node on the canvas. getAudioCurrentTime() is monotonic
+// like Transport but not stateful/resettable, so nothing here can stomp on
+// another node's tracking.
+
+const START_LATENCY = 0.01; // matches the '+0.01' scheduling offset passed to toneNode.start()
 
 function getEntry(id: string): PlayerAudioEntry | undefined {
 	const e = _audioNodes.get(id);
@@ -27,6 +31,7 @@ export const playerHandler: NodeTypeHandler<PlayerNodeData> = {
 			toneNode,
 			split,
 			startOffset:    0,
+			startedAt:      0,
 			currentRate:    1,
 			isExplicitStop: false,
 			isPlaying:      false,
@@ -39,7 +44,6 @@ export const playerHandler: NodeTypeHandler<PlayerNodeData> = {
 				return;
 			}
 			// Natural end of track
-			getTransport().stop();
 			entry.startOffset = 0;
 			entry.isPlaying   = false;
 			entry.playbackEndCb?.();
@@ -60,21 +64,18 @@ export const playerHandler: NodeTypeHandler<PlayerNodeData> = {
 		_audioNodes.delete(id);
 	},
 
-	setAudioParam() { /* playback is driven by the transport helpers below */ },
+	setAudioParam() { /* playback is driven by the operations below */ },
 };
 
-// ─── Transport-coupled playback operations ───────────────────────────────────
+// ─── Playback operations ──────────────────────────────────────────────────────
 
 export async function playNode(id: string): Promise<void> {
 	const entry = getEntry(id);
 	if (!entry) return;
 
-	const transport = getTransport();
 	await toneStart();
-	transport.stop();
-	transport.seconds = 0;
 	entry.toneNode.start('+0.01', entry.startOffset);
-	transport.start('+0.01');
+	entry.startedAt = getAudioCurrentTime() + START_LATENCY;
 	entry.isPlaying = true;
 }
 
@@ -82,11 +83,9 @@ export function pauseNode(id: string): void {
 	const entry = getEntry(id);
 	if (!entry) return;
 
-	const transport = getTransport();
 	entry.startOffset    = getNodePosition(id);
 	entry.isExplicitStop = true;
 	entry.toneNode.stop();
-	transport.stop();
 	entry.isPlaying = false;
 }
 
@@ -94,16 +93,11 @@ export function seekNode(id: string, seconds: number): void {
 	const entry = getEntry(id);
 	if (!entry) return;
 
-	const transport  = getTransport();
-	const wasPlaying = entry.toneNode.state === 'started';
 	entry.startOffset = seconds;
-	if (wasPlaying) {
+	if (entry.toneNode.state === 'started') {
 		entry.isExplicitStop = true;
-		entry.toneNode.stop();
-		transport.stop();
-		transport.seconds = 0;
-		entry.toneNode.start('+0.01', entry.startOffset);
-		transport.start('+0.01');
+		entry.toneNode.seek(seconds);
+		entry.startedAt = getAudioCurrentTime();
 	}
 }
 
@@ -111,15 +105,12 @@ export async function loadTrackForNode(id: string, url: string): Promise<void> {
 	const entry = getEntry(id);
 	if (!entry) return;
 
-	const transport = getTransport();
 	if (entry.toneNode.state === 'started') {
 		entry.isExplicitStop = true;
 		entry.toneNode.stop();
-		transport.stop();
 	}
-	transport.seconds    = 0;
-	entry.startOffset    = 0;
-	entry.isPlaying      = false;
+	entry.startOffset = 0;
+	entry.isPlaying   = false;
 	await entry.toneNode.load(url);
 }
 
@@ -127,12 +118,9 @@ export function setNodeRate(id: string, rate: number): void {
 	const entry = getEntry(id);
 	if (!entry) return;
 
-	const transport = getTransport();
 	if (entry.toneNode.state === 'started') {
 		entry.startOffset = getNodePosition(id);
-		transport.stop();
-		transport.seconds = 0;
-		transport.start('+0.01');
+		entry.startedAt   = getAudioCurrentTime();
 	}
 	entry.currentRate           = rate;
 	entry.toneNode.playbackRate = rate;
@@ -154,7 +142,7 @@ export function getNodePosition(id: string): number {
 	const entry = getEntry(id);
 	if (!entry) return 0;
 	if (!entry.isPlaying) return entry.startOffset;
-	return entry.startOffset + getTransport().seconds * entry.currentRate;
+	return entry.startOffset + (getAudioCurrentTime() - entry.startedAt) * entry.currentRate;
 }
 
 export function getNodeDuration(id: string): number {

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -374,7 +374,8 @@ export type PlayerAudioEntry = {
 	kind:           'player';
 	toneNode:       Player;
 	split:          Split;    // splits stereo output into L (out-0) and R (out-1)
-	startOffset:    number;   // track position (s) at the last play() or seek()
+	startOffset:    number;   // track position (s) as of startedAt
+	startedAt:      number;   // AudioContext time (s) playback most recently began; only valid while isPlaying
 	currentRate:    number;   // mirrors toneNode.playbackRate
 	isExplicitStop: boolean;  // true when stop/pause/seek initiated the onstop
 	isPlaying:      boolean;


### PR DESCRIPTION
## Summary
- `player.ts` (`playNode`/`pauseNode`/`seekNode`/`setNodeRate`/`loadTrackForNode`) seized the global `Tone.Transport` as a hand-rolled stopwatch — stopping it, resetting `.seconds = 0`, restarting it — purely to compute `getNodePosition()`. `Tone.Source` (the base class `Player` extends) starts/stops directly against the AudioContext clock and never touches Transport unless a node opts in via `.sync()`, which this code never did.
- **The bug**: `Tone.Transport` is a singleton shared by every Player node on the canvas. Starting, pausing, or seeking *any* Player node reset `transport.seconds`, silently corrupting the position readout of every *other* concurrently-playing Player node — visible via `PlayerNode.tsx`'s `requestAnimationFrame` scrub-bar loop, which reads `getNodePosition()` every frame.
- **Fix**: position is now `startOffset + (getAudioCurrentTime() - startedAt) * currentRate`, using `getAudioCurrentTime()` (already exported from `audioCore.ts`) — monotonic like Transport but not stateful/resettable by other nodes.
- `seekNode` now calls `Player`'s own built-in `.seek(offset)` instead of hand-rolling stop+start with the same effect (confirmed via the compiled Tone.js source that `.seek()` internally does exactly `_stop(computedTime); _start(computedTime, computedOffset)` against the AudioContext clock).
- `PlayerAudioEntry` gains one field (`startedAt: number`) in place of the removed Transport dependency.

## Test plan
- [x] `tsc --noEmit` — no new errors (10 pre-existing errors remain, all in unrelated files)
- [x] `eslint` on both touched files — clean
- [x] `pnpm run build` — succeeds
- [x] Manual verification in the running app: added two Player nodes, loaded distinct remote tracks into each, played both — both played through to natural completion (`onstop` → "Playback ended" UI message) using the new code path, zero console errors. `Tone.Transport` is no longer referenced anywhere in the file (confirmed via `grep`), so the cross-instance interference bug is structurally eliminated, not just harder to hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)