### PR TITLE
Center value readout, wide-value overflow fix, oscillators on arc sliders

### DIFF
--- a/src/components/hw/HwArcSlider.tsx
+++ b/src/components/hw/HwArcSlider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useRef, useState } from 'react';
+import { useCallback, useId, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { EditInput, useBoundsEdit } from './hwSliderShared';
@@ -37,6 +37,20 @@ function isOnRing(dist: number, r: number) {
 	return Math.abs(dist - r) <= STROKE / 2 + HIT_PAD;
 }
 
+/**
+ * Font size + edit-box width for the centered readout, keyed to how many characters
+ * the formatted value takes ("20" vs "-1200") — long values shrink to stay inside
+ * the ring instead of spilling past it.
+ */
+function valueSizing(chars: number): { fontSize: number; width: number } {
+	if (chars <= 2) return { fontSize: 12, width: 20 };
+	if (chars === 3) return { fontSize: 11, width: 25 };
+	if (chars === 4) return { fontSize: 10, width: 30 };
+	if (chars === 5) return { fontSize: 9,  width: 32 };
+	if (chars === 6) return { fontSize: 9,  width: 34 };
+	return { fontSize: 8, width: 36 };
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export interface HwArcSliderProps {
@@ -51,15 +65,13 @@ export interface HwArcSliderProps {
 	unit?:            string;
 	allowValueEdit?:  boolean;
 	allowBoundsEdit?: boolean;
-	/** Place the label centred below the arc instead of top-left. */
-	labelBelow?:      boolean;
 	/** Outer diameter of the arc (px). Default 64. */
 	size?:            number;
 }
 
 export function HwArcSlider({
 	label, value, min, max, step, color, onChange,
-	format, unit, allowValueEdit, allowBoundsEdit, labelBelow, size = 64,
+	format, unit, allowValueEdit, allowBoundsEdit, size = 64,
 }: HwArcSliderProps) {
 	const uid = useId();
 
@@ -161,116 +173,172 @@ export function HwArcSlider({
 		if (!isNaN(parsed)) onChange(Math.min(localMax, Math.max(localMin, parsed)));
 	}, [onChange, localMin, localMax]);
 
+	const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+		if (editingValue) return;
+		switch (e.key) {
+			case 'ArrowRight':
+			case 'ArrowUp':
+				e.preventDefault();
+				applyValue(value + step);
+				break;
+			case 'ArrowLeft':
+			case 'ArrowDown':
+				e.preventDefault();
+				applyValue(value - step);
+				break;
+			case 'Home':
+				e.preventDefault();
+				applyValue(localMin);
+				break;
+			case 'End':
+				e.preventDefault();
+				applyValue(localMax);
+				break;
+		}
+	}, [editingValue, value, step, applyValue, localMin, localMax]);
+
 	const thumbAngle  = ARC_START + norm * ARC_SWEEP;
 	const [tx, ty]    = polar(cx, cy, r, thumbAngle);
 	const [sx, sy]    = polar(cx, cy, r, ARC_START);
 	const gradientId  = `${filterId}-grad`;
 	const grooveId    = `${filterId}-groove`;
+	const valueSize   = useMemo(() => valueSizing(displayValue.length), [displayValue]);
 
 	return (
 		<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 0.25, width: size }}>
 
-			{/* Label + value row (label omitted here when labelBelow) */}
-			<Box sx={{ display: 'flex', justifyContent: labelBelow ? 'center' : 'space-between', alignItems: 'center', gap: 0.5 }}>
-				{!labelBelow && (
-					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10 }}>
-						{label}
-					</Typography>
-				)}
-				{allowValueEdit && editingValue ? (
-					<EditInput
-						defaultValue={displayValue}
-						onCommit={commitValue}
-						onCancel={() => setEditingValue(false)}
-						fontSize={10} width={36}
-					/>
-				) : (
-					<Typography
-						variant='caption' color='text.disabled'
-						sx={{ fontSize: 10, cursor: allowValueEdit ? 'text' : 'default', userSelect: 'none' }}
-						onClick={allowValueEdit ? () => setEditingValue(true) : undefined}
-					>
-						{displayLabel}
-					</Typography>
-				)}
-			</Box>
+			{/* Label, top center */}
+			<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, textAlign: 'center' }}>
+				{label}
+			</Typography>
 
-			{/* Arc SVG */}
-			<Box
-				component='svg'
-				width={size} height={size}
-				viewBox={`0 0 ${size} ${size}`}
-				sx={{ cursor: hoveringRing ? 'crosshair' : 'default', display: 'block', overflow: 'visible', userSelect: 'none' }}
-				className='nodrag'
-				onMouseDown={handleMouseDown}
-				onMouseMove={handleHoverMove}
-				onMouseLeave={handleHoverLeave}
-			>
-				<defs>
-					<filter id={filterId} x='-80%' y='-80%' width='260%' height='260%'>
-						<feGaussianBlur in='SourceGraphic' stdDeviation='1.8' result='blur' />
-						<feMerge>
-							<feMergeNode in='blur' />
-							<feMergeNode in='SourceGraphic' />
-						</feMerge>
-					</filter>
-					<linearGradient id={gradientId} gradientUnits='userSpaceOnUse'
-						x1={sx} y1={sy} x2={tx} y2={ty}>
-						<stop offset='0%'   stopColor={`${color}80`} />
-						<stop offset='100%' stopColor={color} />
-					</linearGradient>
-					{/* Fixed top-down light source, independent of the arc's rotation — matches the slider rail's inset shading. */}
-					<linearGradient id={grooveId} gradientUnits='userSpaceOnUse'
-						x1={cx} y1={cy - r} x2={cx} y2={cy + r}>
-						<stop offset='0%'   stopColor='#0a0a0c' />
-						<stop offset='50%'  stopColor='#0d0d0f' />
-						<stop offset='100%' stopColor='#131316' />
-					</linearGradient>
-				</defs>
+			{/* Arc SVG + centered value readout */}
+			<Box sx={{ position: 'relative', width: size, height: size }}>
+				<Box
+					component='svg'
+					width={size} height={size}
+					viewBox={`0 0 ${size} ${size}`}
+					sx={{
+						cursor: hoveringRing ? 'crosshair' : 'default', display: 'block', overflow: 'visible', userSelect: 'none',
+						'&:focus-visible': { outline: `2px solid ${color}`, outlineOffset: 2, borderRadius: '50%' },
+					}}
+					className='nodrag'
+					role='slider'
+					tabIndex={0}
+					aria-label={label}
+					aria-valuemin={localMin}
+					aria-valuemax={localMax}
+					aria-valuenow={value}
+					aria-valuetext={displayLabel}
+					onMouseDown={handleMouseDown}
+					onMouseMove={handleHoverMove}
+					onMouseLeave={handleHoverLeave}
+					onKeyDown={handleKeyDown}
+				>
+					<defs>
+						<filter id={filterId} x='-80%' y='-80%' width='260%' height='260%'>
+							<feGaussianBlur in='SourceGraphic' stdDeviation='1.8' result='blur' />
+							<feMerge>
+								<feMergeNode in='blur' />
+								<feMergeNode in='SourceGraphic' />
+							</feMerge>
+						</filter>
+						<linearGradient id={gradientId} gradientUnits='userSpaceOnUse'
+							x1={sx} y1={sy} x2={tx} y2={ty}>
+							<stop offset='0%'   stopColor={`${color}80`} />
+							<stop offset='100%' stopColor={color} />
+						</linearGradient>
+						{/* Fixed top-down light source, independent of the arc's rotation — matches the slider rail's inset shading. */}
+						<linearGradient id={grooveId} gradientUnits='userSpaceOnUse'
+							x1={cx} y1={cy - r} x2={cx} y2={cy + r}>
+							<stop offset='0%'   stopColor='#0a0a0c' />
+							<stop offset='50%'  stopColor='#0d0d0f' />
+							<stop offset='100%' stopColor='#131316' />
+						</linearGradient>
+					</defs>
 
-				{/* Background track — carved groove: dark walls, top-lit face, thin outer-edge highlight */}
-				<path
-					d={arcPath(cx, cy, r, ARC_START, ARC_SWEEP)}
-					fill='none'
-					stroke='#0d0d0f'
-					strokeWidth={STROKE + 2}
-					strokeLinecap='round'
-				/>
-				<path
-					d={arcPath(cx, cy, r, ARC_START, ARC_SWEEP)}
-					fill='none'
-					stroke={`url(#${grooveId})`}
-					strokeWidth={STROKE}
-					strokeLinecap='round'
-				/>
-				<path
-					d={arcPath(cx, cy, r + STROKE / 2 - 0.5, ARC_START, ARC_SWEEP)}
-					fill='none'
-					stroke='rgba(255,255,255,0.05)'
-					strokeWidth={1}
-					strokeLinecap='round'
-				/>
-
-				{/* Value track */}
-				{norm > 0.005 && (
+					{/* Background track — carved groove: dark walls, top-lit face, thin outer-edge highlight */}
 					<path
-						d={arcPath(cx, cy, r, ARC_START, norm * ARC_SWEEP)}
+						d={arcPath(cx, cy, r, ARC_START, ARC_SWEEP)}
 						fill='none'
-						stroke={`url(#${gradientId})`}
+						stroke='#0d0d0f'
+						strokeWidth={STROKE + 2}
+						strokeLinecap='round'
+					/>
+					<path
+						d={arcPath(cx, cy, r, ARC_START, ARC_SWEEP)}
+						fill='none'
+						stroke={`url(#${grooveId})`}
 						strokeWidth={STROKE}
 						strokeLinecap='round'
-						filter={`url(#${filterId})`}
 					/>
-				)}
+					<path
+						d={arcPath(cx, cy, r + STROKE / 2 - 0.5, ARC_START, ARC_SWEEP)}
+						fill='none'
+						stroke='rgba(255,255,255,0.05)'
+						strokeWidth={1}
+						strokeLinecap='round'
+					/>
 
-				{/* Thumb */}
-				<circle
-					cx={tx} cy={ty} r={STROKE - 1}
-					fill='#3a3a42'
-					stroke={color}
-					strokeWidth={1.5}
-					filter={norm > 0.005 ? `url(#${filterId})` : undefined}
-				/>
+					{/* Value track */}
+					{norm > 0.005 && (
+						<path
+							d={arcPath(cx, cy, r, ARC_START, norm * ARC_SWEEP)}
+							fill='none'
+							stroke={`url(#${gradientId})`}
+							strokeWidth={STROKE}
+							strokeLinecap='round'
+							filter={`url(#${filterId})`}
+						/>
+					)}
+
+					{/* Thumb */}
+					<circle
+						cx={tx} cy={ty} r={STROKE}
+						fill='#3a3a42'
+						stroke={color}
+						strokeWidth={1.5}
+						filter={norm > 0.005 ? `url(#${filterId})` : undefined}
+					/>
+				</Box>
+
+				{/* Centered value readout — sits in the dead space the ring-only hit-test already excludes */}
+				<Box sx={{
+					position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+					display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+					pointerEvents: 'none',
+				}}>
+					{allowValueEdit && editingValue ? (
+						<Box sx={{ pointerEvents: 'auto', transform: 'translateY(-2px)' }}>
+							<EditInput
+								defaultValue={displayValue}
+								onCommit={commitValue}
+								onCancel={() => setEditingValue(false)}
+								fontSize={valueSize.fontSize} width={Math.min(size - 28, valueSize.width)}
+								color={color} align='center'
+							/>
+						</Box>
+					) : (
+						<Typography
+							variant='caption' color='text.primary'
+							sx={{
+								fontSize: valueSize.fontSize, fontWeight: 600, lineHeight: 1.1, userSelect: 'none', pointerEvents: 'auto',
+								cursor: allowValueEdit ? 'text' : 'default',
+							}}
+							onClick={allowValueEdit ? () => setEditingValue(true) : undefined}
+						>
+							{displayValue}
+						</Typography>
+					)}
+					{unit && (
+						<Typography
+							variant='caption' color='text.disabled'
+							sx={{ fontSize: 8, lineHeight: 1.2, userSelect: 'none' }}
+						>
+							{unit}
+						</Typography>
+					)}
+				</Box>
 			</Box>
 
 			{/* Bounds row */}
@@ -282,6 +350,7 @@ export function HwArcSlider({
 							onCommit={commitMin}
 							onCancel={() => setEditingMin(false)}
 							compact width={24}
+							color={color} align='center'
 						/>
 					) : (
 						<Typography
@@ -298,6 +367,7 @@ export function HwArcSlider({
 							onCommit={commitMax}
 							onCancel={() => setEditingMax(false)}
 							compact width={24}
+							color={color} align='center'
 						/>
 					) : (
 						<Typography
@@ -309,14 +379,6 @@ export function HwArcSlider({
 						</Typography>
 					)}
 				</Box>
-			)}
-
-			{/* Below-arc label */}
-			{labelBelow && (
-				<Typography variant='caption' color='text.secondary'
-					sx={{ fontSize: 10, textAlign: 'center', mt: 1 }}>
-					{label}
-				</Typography>
 			)}
 
 		</Box>

--- a/src/components/hw/HwSliderField.tsx
+++ b/src/components/hw/HwSliderField.tsx
@@ -46,7 +46,7 @@ export function HwSliderField({
 			<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.25 }}>
 				<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10 }}>{label}</Typography>
 				{allowValueEdit && editingValue ? (
-					<EditInput defaultValue={displayValue} onCommit={commitValue} onCancel={() => setEditingValue(false)} />
+					<EditInput defaultValue={displayValue} onCommit={commitValue} onCancel={() => setEditingValue(false)} color={color} />
 				) : (
 					<Typography
 						variant='caption' color='text.disabled'
@@ -71,7 +71,7 @@ export function HwSliderField({
 			{allowBoundsEdit && (
 				<Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 0.25 }}>
 					{editingMin ? (
-						<EditInput defaultValue={String(localMin)} onCommit={commitMin} onCancel={() => setEditingMin(false)} compact />
+						<EditInput defaultValue={String(localMin)} onCommit={commitMin} onCancel={() => setEditingMin(false)} compact color={color} align='center' />
 					) : (
 						<Typography
 							variant='caption'
@@ -82,7 +82,7 @@ export function HwSliderField({
 						</Typography>
 					)}
 					{editingMax ? (
-						<EditInput defaultValue={String(localMax)} onCommit={commitMax} onCancel={() => setEditingMax(false)} compact />
+						<EditInput defaultValue={String(localMax)} onCommit={commitMax} onCancel={() => setEditingMax(false)} compact color={color} align='center' />
 					) : (
 						<Typography
 							variant='caption'

--- a/src/components/hw/hwSliderShared.tsx
+++ b/src/components/hw/hwSliderShared.tsx
@@ -12,6 +12,8 @@ export function EditInput({
 	compact   = false,
 	fontSize: fontSizeProp,
 	width:    widthProp,
+	color,
+	align     = 'right',
 }: {
 	defaultValue: string;
 	onCommit:     (raw: string) => void;
@@ -21,12 +23,19 @@ export function EditInput({
 	fontSize?:    number;
 	/** Override input width. Defaults to standard slider sizes (54 / 38). */
 	width?:       number;
+	/** Accent the box border/glow with the owning control's color. Neutral gray if omitted. */
+	color?:       string;
+	/** Text alignment within the box. Defaults to 'right' (matches corner-anchored displays). */
+	align?:       'left' | 'center' | 'right';
 }) {
 	const [raw, setRaw] = useState(defaultValue);
 	return (
 		<Box sx={{
 			background:   HW_INSET.background,
-			boxShadow:    `inset 0 0 0 1px #0d0d0f, ${HW_INSET.boxShadow}`,
+			border:       `1px solid ${color ? `${color}50` : '#0d0d0f'}`,
+			boxShadow:    color
+				? `inset 0 2px 4px rgba(0,0,0,0.55), 0 0 6px ${color}30`
+				: 'inset 0 2px 4px rgba(0,0,0,0.55)',
 			borderRadius: HW_INSET.borderRadius,
 			px: 0.5, display: 'inline-flex', alignItems: 'center',
 		}}>
@@ -45,7 +54,7 @@ export function EditInput({
 					fontSize: fontSizeProp ?? (compact ? 8 : 10),
 					color:    'text.primary',
 					width:    widthProp    ?? (compact ? 38 : 54),
-					'& .MuiInputBase-input': { p: 0, textAlign: 'right', lineHeight: 1.66 },
+					'& .MuiInputBase-input': { p: 0, textAlign: align, lineHeight: 1.66 },
 				}}
 			/>
 		</Box>

--- a/src/daw/nodes/effects/AutoFilterNode.tsx
+++ b/src/daw/nodes/effects/AutoFilterNode.tsx
@@ -35,10 +35,10 @@ export const AutoFilterNode = memo(function AutoFilterNode({ id, data, selected 
 					{isRunning ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
-					<HwArcSlider labelBelow label='freq'    value={data.frequency}     min={0.1} max={10}   step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })}     format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
-					<HwArcSlider labelBelow label='base'    value={data.baseFrequency} min={20}  max={2000} step={10}   color={color} onChange={v => setNodeParam(id, { baseFrequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-					<HwArcSlider labelBelow label='octaves' value={data.octaves}       min={1}   max={8}    step={0.1}  color={color} onChange={v => setNodeParam(id, { octaves: v })}       format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
-					<HwArcSlider labelBelow label='wet'     value={data.wet}           min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}           format={v => v.toFixed(2)}            allowValueEdit />
+					<HwArcSlider label='freq'    value={data.frequency}     min={0.1} max={10}   step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })}     format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='base'    value={data.baseFrequency} min={20}  max={2000} step={10}   color={color} onChange={v => setNodeParam(id, { baseFrequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='octaves' value={data.octaves}       min={1}   max={8}    step={0.1}  color={color} onChange={v => setNodeParam(id, { octaves: v })}       format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='wet'     value={data.wet}           min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}           format={v => v.toFixed(2)}            allowValueEdit />
 				</Box>
 			</Box>
 

--- a/src/daw/nodes/effects/AutoPannerNode.tsx
+++ b/src/daw/nodes/effects/AutoPannerNode.tsx
@@ -35,8 +35,8 @@ export const AutoPannerNode = memo(function AutoPannerNode({ id, data, selected 
 					{isRunning ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
-					<HwArcSlider labelBelow label='freq' value={data.frequency} min={0.1} max={10} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
-					<HwArcSlider labelBelow label='wet'  value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
+					<HwArcSlider label='freq' value={data.frequency} min={0.1} max={10} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='wet'  value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
 				</Box>
 			</Box>
 

--- a/src/daw/nodes/effects/AutoWahNode.tsx
+++ b/src/daw/nodes/effects/AutoWahNode.tsx
@@ -20,10 +20,10 @@ export const AutoWahNode = memo(function AutoWahNode({ id, data, selected }: Nod
 			<NodeHeader id={id} label='AutoWah' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='base'    value={data.baseFrequency} min={50}  max={500} step={5}    color={color} onChange={v => setNodeParam(id, { baseFrequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='octaves' value={data.octaves}       min={1}   max={8}   step={0.1}  color={color} onChange={v => setNodeParam(id, { octaves: v })}       format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='sens'    value={data.sensitivity}   min={-40} max={0}   step={1}    color={color} onChange={v => setNodeParam(id, { sensitivity: v })}   format={v => String(v)}    unit='dB' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'     value={data.wet}           min={0}   max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}           format={v => v.toFixed(2)}            allowValueEdit />
+				<HwArcSlider label='base'    value={data.baseFrequency} min={50}  max={500} step={5}    color={color} onChange={v => setNodeParam(id, { baseFrequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='octaves' value={data.octaves}       min={1}   max={8}   step={0.1}  color={color} onChange={v => setNodeParam(id, { octaves: v })}       format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='sens'    value={data.sensitivity}   min={-40} max={0}   step={1}    color={color} onChange={v => setNodeParam(id, { sensitivity: v })}   format={v => String(v)}    unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'     value={data.wet}           min={0}   max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}           format={v => v.toFixed(2)}            allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/BitCrusherNode.tsx
+++ b/src/daw/nodes/effects/BitCrusherNode.tsx
@@ -20,8 +20,8 @@ export const BitCrusherNode = memo(function BitCrusherNode({ id, data, selected 
 			<NodeHeader id={id} label='BitCrusher' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='bits' value={data.bits} min={1} max={16} step={1}    color={color} onChange={v => setNodeParam(id, { bits: v })} format={v => String(Math.round(v))} allowValueEdit />
-				<HwArcSlider labelBelow label='wet'  value={data.wet}  min={0} max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}  format={v => v.toFixed(2)}           allowValueEdit />
+				<HwArcSlider label='bits' value={data.bits} min={1} max={16} step={1}    color={color} onChange={v => setNodeParam(id, { bits: v })} format={v => String(Math.round(v))} allowValueEdit />
+				<HwArcSlider label='wet'  value={data.wet}  min={0} max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}  format={v => v.toFixed(2)}           allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/ChebyshevNode.tsx
+++ b/src/daw/nodes/effects/ChebyshevNode.tsx
@@ -20,8 +20,8 @@ export const ChebyshevNode = memo(function ChebyshevNode({ id, data, selected }:
 			<NodeHeader id={id} label='Chebyshev' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='order' value={data.order} min={1} max={100} step={1}    color={color} onChange={v => setNodeParam(id, { order: v })} format={v => String(Math.round(v))} allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'   value={data.wet}   min={0} max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}   format={v => v.toFixed(2)}           allowValueEdit />
+				<HwArcSlider label='order' value={data.order} min={1} max={100} step={1}    color={color} onChange={v => setNodeParam(id, { order: v })} format={v => String(Math.round(v))} allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'   value={data.wet}   min={0} max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}   format={v => v.toFixed(2)}           allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/ChorusNode.tsx
+++ b/src/daw/nodes/effects/ChorusNode.tsx
@@ -34,10 +34,10 @@ export const ChorusNode = memo(function ChorusNode({ id, data, selected }: NodeP
 				<HwButton color={color} lit={isRunning} sx={{ py: 0.4 }} onClick={handleToggle} fullWidth className='nodrag' aria-label={isRunning ? 'Stop' : 'Start'}>
 					{isRunning ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
-				<HwArcSlider labelBelow label='freq'  value={data.frequency} min={0.1} max={10} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='delay' value={data.delayTime} min={0}   max={20} step={0.1}  color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(1)} unit='ms' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='depth' value={data.depth}     min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { depth: v })}     format={v => v.toFixed(2)}            allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'   value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
+				<HwArcSlider label='freq'  value={data.frequency} min={0.1} max={10} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='delay' value={data.delayTime} min={0}   max={20} step={0.1}  color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(1)} unit='ms' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='depth' value={data.depth}     min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { depth: v })}     format={v => v.toFixed(2)}            allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'   value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/DelayNode.tsx
+++ b/src/daw/nodes/effects/DelayNode.tsx
@@ -20,8 +20,8 @@ export const DelayNode = memo(function DelayNode({ id, data, selected }: NodePro
 			<NodeHeader id={id} label='Delay' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='time' value={data.delayTime} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'  value={data.wet}       min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}        allowValueEdit />
+				<HwArcSlider label='time' value={data.delayTime} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'  value={data.wet}       min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}        allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/DistortionNode.tsx
+++ b/src/daw/nodes/effects/DistortionNode.tsx
@@ -24,8 +24,8 @@ export const DistortionNode = memo(function DistortionNode({ id, data, selected 
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
 				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
-					<HwArcSlider labelBelow label='drive' value={data.distortion} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { distortion: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
-					<HwArcSlider labelBelow label='wet'   value={data.wet}        min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)} allowValueEdit />
+					<HwArcSlider label='drive' value={data.distortion} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { distortion: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='wet'   value={data.wet}        min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)} allowValueEdit />
 				</Box>
 				<HwToggleButtonGroup color={color} value={data.oversample} exclusive
 					onChange={(_, v) => v && setNodeParam(id, { oversample: v })} className='nodrag'>

--- a/src/daw/nodes/effects/FeedbackDelayNode.tsx
+++ b/src/daw/nodes/effects/FeedbackDelayNode.tsx
@@ -20,9 +20,9 @@ export const FeedbackDelayNode = memo(function FeedbackDelayNode({ id, data, sel
 			<NodeHeader id={id} label='FeedbackDelay' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='time'     value={data.delayTime} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='feedback' value={data.feedback}  min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { feedback: v })}  format={v => v.toFixed(2)}          allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'      value={data.wet}       min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}          allowValueEdit />
+				<HwArcSlider label='time'     value={data.delayTime} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='feedback' value={data.feedback}  min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { feedback: v })}  format={v => v.toFixed(2)}          allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'      value={data.wet}       min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}          allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/FreeverbNode.tsx
+++ b/src/daw/nodes/effects/FreeverbNode.tsx
@@ -20,9 +20,9 @@ export const FreeverbNode = memo(function FreeverbNode({ id, data, selected }: N
 			<NodeHeader id={id} label='Freeverb' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='roomSize'  value={data.roomSize}  min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { roomSize: v })}  format={v => v.toFixed(2)}        allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='dampening' value={data.dampening} min={100} max={8000} step={10}   color={color} onChange={v => setNodeParam(id, { dampening: v })} format={v => String(v)} unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'       value={data.wet}       min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}        allowValueEdit />
+				<HwArcSlider label='roomSize'  value={data.roomSize}  min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { roomSize: v })}  format={v => v.toFixed(2)}        allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='dampening' value={data.dampening} min={100} max={8000} step={10}   color={color} onChange={v => setNodeParam(id, { dampening: v })} format={v => String(v)} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'       value={data.wet}       min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}        allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/FrequencyShifterNode.tsx
+++ b/src/daw/nodes/effects/FrequencyShifterNode.tsx
@@ -20,8 +20,8 @@ export const FrequencyShifterNode = memo(function FrequencyShifterNode({ id, dat
 			<NodeHeader id={id} label='FreqShifter' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='freq' value={data.frequency} min={-1000} max={1000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(v)} unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'  value={data.wet}       min={0}     max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}          allowValueEdit />
+				<HwArcSlider label='freq' value={data.frequency} min={-1000} max={1000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(v)} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'  value={data.wet}       min={0}     max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}          allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/JCReverbNode.tsx
+++ b/src/daw/nodes/effects/JCReverbNode.tsx
@@ -20,8 +20,8 @@ export const JCReverbNode = memo(function JCReverbNode({ id, data, selected }: N
 			<NodeHeader id={id} label='JCReverb' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='roomSize' value={data.roomSize} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { roomSize: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'      value={data.wet}      min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}      format={v => v.toFixed(2)} allowValueEdit />
+				<HwArcSlider label='roomSize' value={data.roomSize} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { roomSize: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'      value={data.wet}      min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}      format={v => v.toFixed(2)} allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/PhaserNode.tsx
+++ b/src/daw/nodes/effects/PhaserNode.tsx
@@ -20,10 +20,10 @@ export const PhaserNode = memo(function PhaserNode({ id, data, selected }: NodeP
 			<NodeHeader id={id} label='Phaser' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='freq'    value={data.frequency}     min={0.1} max={10}   step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })}     format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='octaves' value={data.octaves}       min={1}   max={8}    step={0.1}  color={color} onChange={v => setNodeParam(id, { octaves: v })}       format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='base'    value={data.baseFrequency} min={200} max={1000} step={10}   color={color} onChange={v => setNodeParam(id, { baseFrequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'     value={data.wet}           min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}           format={v => v.toFixed(2)}            allowValueEdit />
+				<HwArcSlider label='freq'    value={data.frequency}     min={0.1} max={10}   step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })}     format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='octaves' value={data.octaves}       min={1}   max={8}    step={0.1}  color={color} onChange={v => setNodeParam(id, { octaves: v })}       format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='base'    value={data.baseFrequency} min={200} max={1000} step={10}   color={color} onChange={v => setNodeParam(id, { baseFrequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'     value={data.wet}           min={0}   max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}           format={v => v.toFixed(2)}            allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/PingPongDelayNode.tsx
+++ b/src/daw/nodes/effects/PingPongDelayNode.tsx
@@ -20,9 +20,9 @@ export const PingPongDelayNode = memo(function PingPongDelayNode({ id, data, sel
 			<NodeHeader id={id} label='PingPongDelay' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='time'     value={data.delayTime} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='feedback' value={data.feedback}  min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { feedback: v })}  format={v => v.toFixed(2)}          allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'      value={data.wet}       min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}          allowValueEdit />
+				<HwArcSlider label='time'     value={data.delayTime} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { delayTime: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='feedback' value={data.feedback}  min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { feedback: v })}  format={v => v.toFixed(2)}          allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'      value={data.wet}       min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}          allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/PitchShiftNode.tsx
+++ b/src/daw/nodes/effects/PitchShiftNode.tsx
@@ -20,10 +20,10 @@ export const PitchShiftNode = memo(function PitchShiftNode({ id, data, selected 
 			<NodeHeader id={id} label='PitchShift' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='pitch'  value={data.pitch}      min={-12}  max={12}  step={1}    color={color} onChange={v => setNodeParam(id, { pitch: v })}      format={v => String(v)}    unit='st' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='window' value={data.windowSize} min={0.03} max={0.1} step={0.01} color={color} onChange={v => setNodeParam(id, { windowSize: v })} format={v => v.toFixed(2)} unit='s'  allowValueEdit />
-				<HwArcSlider labelBelow label='fdbk'   value={data.feedback}   min={0}    max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { feedback: v })}   format={v => v.toFixed(2)}           allowValueEdit />
-				<HwArcSlider labelBelow label='wet'    value={data.wet}        min={0}    max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}           allowValueEdit />
+				<HwArcSlider label='pitch'  value={data.pitch}      min={-12}  max={12}  step={1}    color={color} onChange={v => setNodeParam(id, { pitch: v })}      format={v => String(v)}    unit='st' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='window' value={data.windowSize} min={0.03} max={0.1} step={0.01} color={color} onChange={v => setNodeParam(id, { windowSize: v })} format={v => v.toFixed(2)} unit='s'  allowValueEdit />
+				<HwArcSlider label='fdbk'   value={data.feedback}   min={0}    max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { feedback: v })}   format={v => v.toFixed(2)}           allowValueEdit />
+				<HwArcSlider label='wet'    value={data.wet}        min={0}    max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}        format={v => v.toFixed(2)}           allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/ReverbNode.tsx
+++ b/src/daw/nodes/effects/ReverbNode.tsx
@@ -20,9 +20,9 @@ export const ReverbNode = memo(function ReverbNode({ id, data, selected }: NodeP
 			<NodeHeader id={id} label='Reverb' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='decay'    value={data.decay}    min={0.1} max={10}  step={0.1}  color={color} onChange={v => setNodeParam(id, { decay: v })}    format={v => v.toFixed(1)} unit='s'  allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='preDelay' value={data.preDelay} min={0}   max={0.5} step={0.01} color={color} onChange={v => setNodeParam(id, { preDelay: v })} format={v => v.toFixed(2)} unit='s'  allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'      value={data.wet}      min={0}   max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}      format={v => v.toFixed(2)}            allowValueEdit />
+				<HwArcSlider label='decay'    value={data.decay}    min={0.1} max={10}  step={0.1}  color={color} onChange={v => setNodeParam(id, { decay: v })}    format={v => v.toFixed(1)} unit='s'  allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='preDelay' value={data.preDelay} min={0}   max={0.5} step={0.01} color={color} onChange={v => setNodeParam(id, { preDelay: v })} format={v => v.toFixed(2)} unit='s'  allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'      value={data.wet}      min={0}   max={1}   step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}      format={v => v.toFixed(2)}            allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/StereoWidenerNode.tsx
+++ b/src/daw/nodes/effects/StereoWidenerNode.tsx
@@ -20,8 +20,8 @@ export const StereoWidenerNode = memo(function StereoWidenerNode({ id, data, sel
 			<NodeHeader id={id} label='StereoWidener' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='width' value={data.width} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { width: v })} format={v => v.toFixed(2)} allowValueEdit />
-				<HwArcSlider labelBelow label='wet'   value={data.wet}   min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}   format={v => v.toFixed(2)} allowValueEdit />
+				<HwArcSlider label='width' value={data.width} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { width: v })} format={v => v.toFixed(2)} allowValueEdit />
+				<HwArcSlider label='wet'   value={data.wet}   min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}   format={v => v.toFixed(2)} allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/TremoloNode.tsx
+++ b/src/daw/nodes/effects/TremoloNode.tsx
@@ -34,9 +34,9 @@ export const TremoloNode = memo(function TremoloNode({ id, data, selected }: Nod
 				<HwButton color={color} lit={isRunning} sx={{ py: 0.4 }} onClick={handleToggle} fullWidth className='nodrag' aria-label={isRunning ? 'Stop' : 'Start'}>
 					{isRunning ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
-				<HwArcSlider labelBelow label='freq'  value={data.frequency} min={0.1} max={20} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='depth' value={data.depth}     min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { depth: v })}     format={v => v.toFixed(2)}            allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'   value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
+				<HwArcSlider label='freq'  value={data.frequency} min={0.1} max={20} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='depth' value={data.depth}     min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { depth: v })}     format={v => v.toFixed(2)}            allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'   value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/effects/VibratoNode.tsx
+++ b/src/daw/nodes/effects/VibratoNode.tsx
@@ -20,9 +20,9 @@ export const VibratoNode = memo(function VibratoNode({ id, data, selected }: Nod
 			<NodeHeader id={id} label='Vibrato' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider labelBelow label='freq'  value={data.frequency} min={0.1} max={20} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='depth' value={data.depth}     min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { depth: v })}     format={v => v.toFixed(2)}            allowValueEdit allowBoundsEdit />
-				<HwArcSlider labelBelow label='wet'   value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
+				<HwArcSlider label='freq'  value={data.frequency} min={0.1} max={20} step={0.1}  color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => v.toFixed(1)} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='depth' value={data.depth}     min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { depth: v })}     format={v => v.toFixed(2)}            allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='wet'   value={data.wet}       min={0}   max={1}  step={0.01} color={color} onChange={v => setNodeParam(id, { wet: v })}       format={v => v.toFixed(2)}            allowValueEdit />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/source/AMOscillatorNode.tsx
+++ b/src/daw/nodes/source/AMOscillatorNode.tsx
@@ -12,7 +12,7 @@ import { bottomOutputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { HW_RAISED, hwLit } from '../shared/hwStyles';
 import { HwButton } from '../shared/hwComponents';
-import { HwSliderField } from '../../../components/hw/HwSliderField';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
 import { WAVE_ICONS, OSC_TYPES } from '../shared/WaveformIcons';
 import type { AMOscillatorFlowNode, OscType } from '../../../store/dawTypes';
 
@@ -78,17 +78,11 @@ export const AMOscillatorNode = memo(function AMOscillatorNode({ id, data, selec
 					{isPlaying ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='freq'        value={data.frequency}   min={20}    max={4000} step={1}   color={color} onChange={v => setNodeParam(id, { frequency: v })}   format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='harmonicity' value={data.harmonicity} min={0}     max={20}   step={0.1} color={color} onChange={v => setNodeParam(id, { harmonicity: v })} format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='detune'      value={data.detune}      min={-1200} max={1200} step={1}   color={color} onChange={v => setNodeParam(id, { detune: v })}      format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='phase'       value={data.phase}       min={0}     max={360}  step={1}   color={color} onChange={v => setNodeParam(id, { phase: v })}       format={v => String(v)}    unit='°'  allowValueEdit />
+				<Box className='nodrag nowheel' sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'        value={data.frequency}   min={20}    max={4000} step={1}   color={color} onChange={v => setNodeParam(id, { frequency: v })}   format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='harmonicity' value={data.harmonicity} min={0}     max={20}   step={0.1} color={color} onChange={v => setNodeParam(id, { harmonicity: v })} format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='detune'      value={data.detune}      min={-1200} max={1200} step={1}   color={color} onChange={v => setNodeParam(id, { detune: v })}      format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='phase'       value={data.phase}       min={0}     max={360}  step={1}   color={color} onChange={v => setNodeParam(id, { phase: v })}       format={v => String(v)}    unit='°'  allowValueEdit />
 				</Box>
 
 			</Box>

--- a/src/daw/nodes/source/FMOscillatorNode.tsx
+++ b/src/daw/nodes/source/FMOscillatorNode.tsx
@@ -12,7 +12,7 @@ import { bottomOutputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { HW_RAISED, hwLit } from '../shared/hwStyles';
 import { HwButton } from '../shared/hwComponents';
-import { HwSliderField } from '../../../components/hw/HwSliderField';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
 import { WAVE_ICONS, OSC_TYPES } from '../shared/WaveformIcons';
 import type { FMOscillatorFlowNode, OscType } from '../../../store/dawTypes';
 
@@ -78,20 +78,12 @@ export const FMOscillatorNode = memo(function FMOscillatorNode({ id, data, selec
 					{isPlaying ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='freq'        value={data.frequency}       min={20}    max={4000} step={1}   color={color} onChange={v => setNodeParam(id, { frequency: v })}       format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='mod idx'     value={data.modulationIndex} min={0}     max={50}   step={0.1} color={color} onChange={v => setNodeParam(id, { modulationIndex: v })} format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='harmonicity' value={data.harmonicity}     min={0}     max={20}   step={0.1} color={color} onChange={v => setNodeParam(id, { harmonicity: v })}     format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='detune'      value={data.detune}          min={-1200} max={1200} step={1}   color={color} onChange={v => setNodeParam(id, { detune: v })}          format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='phase'       value={data.phase}           min={0}     max={360}  step={1}   color={color} onChange={v => setNodeParam(id, { phase: v })}           format={v => String(v)}    unit='°'  allowValueEdit />
+				<Box className='nodrag nowheel' sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'        value={data.frequency}       min={20}    max={4000} step={1}   color={color} onChange={v => setNodeParam(id, { frequency: v })}       format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='mod idx'     value={data.modulationIndex} min={0}     max={50}   step={0.1} color={color} onChange={v => setNodeParam(id, { modulationIndex: v })} format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='harmonicity' value={data.harmonicity}     min={0}     max={20}   step={0.1} color={color} onChange={v => setNodeParam(id, { harmonicity: v })}     format={v => v.toFixed(1)}            allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='detune'      value={data.detune}          min={-1200} max={1200} step={1}   color={color} onChange={v => setNodeParam(id, { detune: v })}          format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='phase'       value={data.phase}           min={0}     max={360}  step={1}   color={color} onChange={v => setNodeParam(id, { phase: v })}           format={v => String(v)}    unit='°'  allowValueEdit />
 				</Box>
 
 			</Box>

--- a/src/daw/nodes/source/FatOscillatorNode.tsx
+++ b/src/daw/nodes/source/FatOscillatorNode.tsx
@@ -12,7 +12,7 @@ import { bottomOutputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { HW_RAISED, hwLit } from '../shared/hwStyles';
 import { HwButton } from '../shared/hwComponents';
-import { HwSliderField } from '../../../components/hw/HwSliderField';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
 import { WAVE_ICONS, OSC_TYPES } from '../shared/WaveformIcons';
 import type { FatOscillatorFlowNode, OscType } from '../../../store/dawTypes';
 
@@ -67,20 +67,12 @@ export const FatOscillatorNode = memo(function FatOscillatorNode({ id, data, sel
 					{isPlaying ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='freq'   value={data.frequency} min={20}    max={4000} step={1}   color={color} onChange={v => setNodeParam(id, { frequency: v })}          format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='voices' value={data.count}     min={1}     max={5}    step={1}   color={color} onChange={v => setNodeParam(id, { count: Math.round(v) })}  format={v => String(Math.round(v))}  allowValueEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='spread' value={data.spread}    min={0}     max={100}  step={1}   color={color} onChange={v => setNodeParam(id, { spread: v })}             format={v => String(v)}    unit='¢' allowValueEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='detune' value={data.detune}    min={-1200} max={1200} step={1}   color={color} onChange={v => setNodeParam(id, { detune: v })}             format={v => String(v)}    unit='ct' allowValueEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='phase'  value={data.phase}     min={0}     max={360}  step={1}   color={color} onChange={v => setNodeParam(id, { phase: v })}              format={v => String(v)}    unit='°'  allowValueEdit />
+				<Box className='nodrag nowheel' sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'   value={data.frequency} min={20}    max={4000} step={1}   color={color} onChange={v => setNodeParam(id, { frequency: v })}          format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='voices' value={data.count}     min={1}     max={5}    step={1}   color={color} onChange={v => setNodeParam(id, { count: Math.round(v) })}  format={v => String(Math.round(v))}  allowValueEdit />
+					<HwArcSlider label='spread' value={data.spread}    min={0}     max={100}  step={1}   color={color} onChange={v => setNodeParam(id, { spread: v })}             format={v => String(v)}    unit='¢' allowValueEdit />
+					<HwArcSlider label='detune' value={data.detune}    min={-1200} max={1200} step={1}   color={color} onChange={v => setNodeParam(id, { detune: v })}             format={v => String(v)}    unit='ct' allowValueEdit />
+					<HwArcSlider label='phase'  value={data.phase}     min={0}     max={360}  step={1}   color={color} onChange={v => setNodeParam(id, { phase: v })}              format={v => String(v)}    unit='°'  allowValueEdit />
 				</Box>
 
 			</Box>

--- a/src/daw/nodes/source/OscillatorNode.tsx
+++ b/src/daw/nodes/source/OscillatorNode.tsx
@@ -12,7 +12,7 @@ import { bottomOutputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { HW_RAISED, hwLit } from '../shared/hwStyles';
 import { HwButton } from '../shared/hwComponents';
-import { HwSliderField } from '../../../components/hw/HwSliderField';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
 import { WAVE_ICONS, OSC_TYPES } from '../shared/WaveformIcons';
 import type { OscillatorFlowNode } from '../../../store/dawTypes';
 
@@ -67,14 +67,10 @@ export const OscillatorNode = memo(function OscillatorNode({ id, data, selected 
 					{isPlaying ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='freq'   value={data.frequency} min={20}    max={4000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='detune' value={data.detune}    min={-1200} max={1200} step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}    format={v => String(v)}    unit='ct' allowValueEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='phase'  value={data.phase}     min={0}     max={360}  step={1}    color={color} onChange={v => setNodeParam(id, { phase: v })}     format={v => String(v)}    unit='°'  allowValueEdit />
+				<Box className='nodrag nowheel' sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'   value={data.frequency} min={20}    max={4000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='detune' value={data.detune}    min={-1200} max={1200} step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}    format={v => String(v)}    unit='ct' allowValueEdit />
+					<HwArcSlider label='phase'  value={data.phase}     min={0}     max={360}  step={1}    color={color} onChange={v => setNodeParam(id, { phase: v })}     format={v => String(v)}    unit='°'  allowValueEdit />
 				</Box>
 
 			</Box>

--- a/src/daw/nodes/source/PWMOscillatorNode.tsx
+++ b/src/daw/nodes/source/PWMOscillatorNode.tsx
@@ -10,7 +10,7 @@ import { GRID_UNIT } from '../shared/gridSystem';
 import { bottomOutputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { HwButton } from '../shared/hwComponents';
-import { HwSliderField } from '../../../components/hw/HwSliderField';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
 import type { PWMOscillatorFlowNode } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.source;
@@ -37,17 +37,11 @@ export const PWMOscillatorNode = memo(function PWMOscillatorNode({ id, data, sel
 					{isPlaying ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='freq'     value={data.frequency}           min={20}    max={4000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })}           format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='mod freq' value={data.modulationFrequency} min={0.1}   max={20}   step={0.01} color={color} onChange={v => setNodeParam(id, { modulationFrequency: v })} format={v => v.toFixed(2)} unit='Hz' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='detune'   value={data.detune}              min={-1200} max={1200} step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}              format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='phase'    value={data.phase}               min={0}     max={360}  step={1}    color={color} onChange={v => setNodeParam(id, { phase: v })}               format={v => String(v)}    unit='°'  allowValueEdit />
+				<Box className='nodrag nowheel' sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'     value={data.frequency}           min={20}    max={4000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })}           format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='mod freq' value={data.modulationFrequency} min={0.1}   max={20}   step={0.01} color={color} onChange={v => setNodeParam(id, { modulationFrequency: v })} format={v => v.toFixed(2)} unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='detune'   value={data.detune}              min={-1200} max={1200} step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}              format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='phase'    value={data.phase}               min={0}     max={360}  step={1}    color={color} onChange={v => setNodeParam(id, { phase: v })}               format={v => String(v)}    unit='°'  allowValueEdit />
 				</Box>
 
 			</Box>

--- a/src/daw/nodes/source/PulseOscillatorNode.tsx
+++ b/src/daw/nodes/source/PulseOscillatorNode.tsx
@@ -10,7 +10,7 @@ import { GRID_UNIT } from '../shared/gridSystem';
 import { bottomOutputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { HwButton } from '../shared/hwComponents';
-import { HwSliderField } from '../../../components/hw/HwSliderField';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
 import type { PulseOscillatorFlowNode } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.source;
@@ -37,17 +37,11 @@ export const PulseOscillatorNode = memo(function PulseOscillatorNode({ id, data,
 					{isPlaying ? <StopIcon sx={{ fontSize: 13 }} /> : <PlayArrowIcon sx={{ fontSize: 13 }} />}
 				</HwButton>
 
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='freq'   value={data.frequency} min={20}    max={4000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='width'  value={data.width}     min={0}     max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { width: v })}     format={v => v.toFixed(2)}           allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='detune' value={data.detune}    min={-1200} max={1200} step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}    format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
-				</Box>
-				<Box className='nodrag nowheel'>
-					<HwSliderField label='phase'  value={data.phase}     min={0}     max={360}  step={1}    color={color} onChange={v => setNodeParam(id, { phase: v })}     format={v => String(v)}    unit='°'  allowValueEdit />
+				<Box className='nodrag nowheel' sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'   value={data.frequency} min={20}    max={4000} step={1}    color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(v)}    unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='width'  value={data.width}     min={0}     max={1}    step={0.01} color={color} onChange={v => setNodeParam(id, { width: v })}     format={v => v.toFixed(2)}           allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='detune' value={data.detune}    min={-1200} max={1200} step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}    format={v => String(v)}    unit='ct' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='phase'  value={data.phase}     min={0}     max={360}  step={1}    color={color} onChange={v => setNodeParam(id, { phase: v })}     format={v => String(v)}    unit='°'  allowValueEdit />
 				</Box>
 
 			</Box>


### PR DESCRIPTION
## Summary
Follow-up to #14 (merged). Three logical changes on `HwArcSlider` and its consumers:

1. **Center value readout** — value moves from the corner into the arc's dead center (now unused for dragging since #14's ring-only hit-test), with click-to-edit following it. Label always renders top-center. Adds baseline accessibility: `role="slider"`, `aria-valuemin/max/now/text`, keyboard support (arrows/Home/End), visible focus ring. `EditInput` (`hwSliderShared.tsx`) gains `color` (accent border/glow) and `align` props, used by both `HwArcSlider` and `HwSliderField`.
2. **Dead prop cleanup** — `labelBelow` dropped from `HwArcSlider`'s API (every call site already passed it unconditionally) and stripped from the 19 effects nodes that referenced it.
3. **Oscillator nodes on arc sliders** — all six oscillator nodes (Oscillator, AM, FM, PWM, Fat, Pulse) swapped from `HwSliderField` to `HwArcSlider`, same parameters, laid out in the flex-wrap grid pattern effects nodes already use.

Also fixes an overflow bug found while testing the oscillator swap: wide-range params (`detune` ±1200, `freq` up to 4000) were spilling text past the ring in both the at-rest and edit states. Font size and edit-box width now scale down based on the formatted value's character count.

## Test plan
- [x] `npx tsc --noEmit` — no new errors (10 pre-existing, unrelated)
- [x] `npx eslint` on all touched files — clean (including a `react-hooks/preserve-manual-memoization` compiler warning resolved via `useMemo`)
- [ ] Manual: check oscillator + effects node knobs render correctly, edit-in-place works, keyboard nav works, no overflow on wide-range params (detune, freq)

🤖 Generated with [Claude Code](https://claude.com/claude-code)