### PR TITLE
Record ADRs for Tier 2 node buildout decisions

### DIFF
--- a/docs/adr/0001-shared-tap-readout-hook.md
+++ b/docs/adr/0001-shared-tap-readout-hook.md
@@ -1,11 +1,18 @@
-# Shared tap+readout hook for Analysis nodes
+# Shared tap+readout hook for canvas-drawing Analysis nodes
 
-Tier 1 shipped four Analysis nodes (FFT, Meter, DCMeter, Waveform) that each pass audio through
-unchanged and poll a `getValue()`-family method via their own `requestAnimationFrame` loop,
-duplicated near-identically across `FFTNode.tsx`/`MeterNode.tsx`/`DCMeterNode.tsx`/
-`WaveformNode.tsx`. Tier 2 adds a fifth, Analyser. Rather than add a fifth bespoke copy, we're
-extracting a shared hook that owns the rAF polling loop and returns the latest value; each node
-keeps its own draw/render logic (bar spectrum, line waveform, needle meter, etc. genuinely
-differ), and the four existing nodes get refactored onto it in the same batch. Five instances of
-the same polling loop is the point where the duplication risk (one copy silently drifting from
-the other four) outweighs the cost of the refactor touching already-shipped files.
+Tier 1 shipped four Analysis nodes that each pass audio through unchanged and poll a
+`getValue()`-family method for a live readout, but they split into two genuinely different
+rendering shapes, not one: FFT and Waveform each run their own `requestAnimationFrame` loop that
+draws straight to a `<canvas>`, bypassing React state entirely for frame-rate reasons; Meter and
+DCMeter instead poll via `setInterval(100ms)`, feeding a numeric readout and an `HwLevelMeter` bar
+through plain React state. On inspection these aren't one duplicated pattern, they're two — and
+only the first (FFT/Waveform) is what Analyser needs, since Analyser's `type` param toggles
+between drawing an FFT spectrum and a waveform line, i.e. it's the union of exactly what FFT and
+Waveform already each do.
+
+We're extracting a shared hook for the rAF+canvas shape only — it owns the polling loop and
+returns the latest value, each node keeps its own draw call (bar spectrum vs line trace) — and
+refactoring `FFTNode.tsx`/`WaveformNode.tsx` onto it alongside building `AnalyserNode.tsx` on the
+same hook. `MeterNode.tsx`/`DCMeterNode.tsx` are left as they are: forcing their
+setInterval+React-state pattern into the same abstraction as the canvas one would be unifying two
+things that only superficially look alike, not removing real duplication.

--- a/docs/adr/0001-shared-tap-readout-hook.md
+++ b/docs/adr/0001-shared-tap-readout-hook.md
@@ -1,0 +1,11 @@
+# Shared tap+readout hook for Analysis nodes
+
+Tier 1 shipped four Analysis nodes (FFT, Meter, DCMeter, Waveform) that each pass audio through
+unchanged and poll a `getValue()`-family method via their own `requestAnimationFrame` loop,
+duplicated near-identically across `FFTNode.tsx`/`MeterNode.tsx`/`DCMeterNode.tsx`/
+`WaveformNode.tsx`. Tier 2 adds a fifth, Analyser. Rather than add a fifth bespoke copy, we're
+extracting a shared hook that owns the rAF polling loop and returns the latest value; each node
+keeps its own draw/render logic (bar spectrum, line waveform, needle meter, etc. genuinely
+differ), and the four existing nodes get refactored onto it in the same batch. Five instances of
+the same polling loop is the point where the duplication risk (one copy silently drifting from
+the other four) outweighs the cost of the refactor touching already-shipped files.

--- a/docs/adr/0002-signal-math-nodes-slider-only-v1.md
+++ b/docs/adr/0002-signal-math-nodes-slider-only-v1.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# Add/Multiply/GreaterThan ship slider-only, not two-signal wiring
+
+Tone.js's second operand for `Add`, `Multiply`, and `GreaterThan` (`.addend`/`.factor`/
+`.comparator`) is a `Param`, not a second `InputNode` — a different attachment point than the
+`in-N → toneNode.input` convention every handler in `nodeHandler.ts` currently assumes. True
+two-signal wiring (a second handle connected directly to that `Param`) would be the more capable
+design, but it means widening the handle→input contract for the first time, which deserves its
+own deliberate design pass rather than landing incidentally inside a Tier 2 node batch. We're
+shipping v1 as a single audio-in handle + a value slider for the constant operand, matching
+`gain.ts`'s existing pattern exactly. Two-handle wiring to the `Param` remains a flagged, explicit
+future extension — not something to bolt on silently later.
+
+## Considered Options
+
+- **Two-handle wiring now** — rejected for this batch: changes a core handler contract
+  (`nodeHandler.ts`'s in-N→input assumption) as a side effect of routine node buildout, not as its
+  own reviewed decision.
+- **Slider-only v1** — chosen: ships fast, matches an established pattern, defers the contract
+  change to when it's deliberately designed.

--- a/docs/adr/0003-solo-cross-instance-state.md
+++ b/docs/adr/0003-solo-cross-instance-state.md
@@ -1,0 +1,18 @@
+# Solo's cross-instance mute state: store-driven, not polled
+
+Soloing one `Solo` node must mute every other `Solo`/`Channel` instance sharing the audio context.
+Tone.js already does this for free via its own internal static registry — that part needs no new
+code. What's new is that reactoscope's UI also needs every *other* node's displayed state to
+update in response, which no existing node does today (every other node's param changes are
+purely local to itself).
+
+We're keeping audio truth and UI truth in separate places: Tone's registry stays the source of
+truth for actual audio muting, and the `daw.ts` store gains a field tracking which node id (if
+any) is currently soloed. `SoloNode` (and later `Channel`) components read that store field to
+render other instances' dimmed/muted visual state, rather than polling Tone's internal registry
+on an interval the way the tap+readout nodes poll audio levels. Polling was the other option
+considered — it would have repurposed a pattern meant for continuous audio signals to track a
+discrete boolean toggle, and would have required exposing Tone's internal registry through
+`engine.ts`'s public surface, which it isn't today. This is the first node in the catalogue where
+one instance's param change needs to visibly affect other node components' displayed state; the
+same store-field pattern is expected to extend to `Channel`'s built-in solo behavior later.


### PR DESCRIPTION
## Summary
- Resolved four open Tier 2 design/architecture questions from `docs/node-roadmap.md`'s cross-cutting notes via a grilling-skill interview
- Recorded the three that met the "hard to reverse + surprising + real trade-off" bar as ADRs:
  - `0001-shared-tap-readout-hook.md` — extract a shared rAF-polling hook for Analysis nodes (Analyser + refactor of the four existing Tier 1 nodes) instead of a 5th bespoke copy
  - `0002-signal-math-nodes-slider-only-v1.md` — Add/Multiply/GreaterThan ship audio-in + slider v1, defer two-signal Param wiring as a deliberate future extension
  - `0003-solo-cross-instance-state.md` — Solo's cross-instance mute state lives in the `daw.ts` store, not polled from Tone's internal registry
- Also decided (not ADR-worthy — easily reversible, low-stakes scoping): batch Tier 2 by risk (routine params-only nodes first, then Solo, then Convolver, then the signal-math nodes each on their own), Convolver starts silent with no bundled IR, Compressor's `reduction` meter deferred to a later batch

## Test plan
- [ ] N/A — docs only, no code changes