### PR TITLE
Implement Tier 2 routine batch: Compressor, Filter, EQ3, MultibandSplit, Analyser, Follower

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -108,6 +108,19 @@ const mergeNodeAdapter: PortAdapter = {
 	getOutput: (entry) => entry.kind === 'merge' ? { node: entry.toneNode, channel: 0 } : null,
 };
 
+const multibandSplitAdapter: PortAdapter = {
+	// MultibandSplit: plain Gain input, but no single `.output` — out-0/1/2
+	// select the low/mid/high child Filter instances directly.
+	getInput: (entry) => entry.kind === 'multibandSplit' ? { node: entry.toneNode, channel: 0 } : null,
+	getOutput: (entry, sourceHandle) => {
+		if (entry.kind !== 'multibandSplit') return null;
+		const node = sourceHandle === 'out-1' ? entry.toneNode.mid
+			: sourceHandle === 'out-2' ? entry.toneNode.high
+			: entry.toneNode.low;
+		return { node, channel: 0 };
+	},
+};
+
 const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	masterOutput: masterOutputAdapter,
 	player:       splitOutputAdapter,
@@ -116,6 +129,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	delay:        delayAdapter,
 	split:        splitNodeAdapter,
 	merge:        mergeNodeAdapter,
+	multibandSplit: multibandSplitAdapter,
 	oscillator:       genericAdapter,
 	gain:             genericAdapter,
 	noise:            genericAdapter,
@@ -147,7 +161,10 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	autoWah:          genericAdapter,
 	limiter:          genericAdapter,
 	gate:             genericAdapter,
+	compressor:       genericAdapter,
 	biquadFilter:     genericAdapter,
+	filter:           genericAdapter,
+	eq3:              genericAdapter,
 	panVol:           genericAdapter,
 	mono:             genericAdapter,
 	volume:           genericAdapter,
@@ -155,6 +172,8 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	meter:            genericAdapter,
 	dcMeter:          genericAdapter,
 	waveform:         genericAdapter,
+	analyser:         genericAdapter,
+	follower:         genericAdapter,
 	signal:           genericAdapter,
 	scale:            genericAdapter,
 	scaleExp:         genericAdapter,

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -171,3 +171,4 @@ export { getFFTValue }     from './nodes/fft';
 export { getMeterValue }   from './nodes/meter';
 export { getDCMeterValue } from './nodes/dcMeter';
 export { getWaveformValue } from './nodes/waveform';
+export { getAnalyserValue } from './nodes/analyser';

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -52,6 +52,12 @@ import { absHandler }              from './nodes/abs';
 import { negateHandler }           from './nodes/negate';
 import { audioToGainHandler }      from './nodes/audioToGain';
 import { gainToAudioHandler }      from './nodes/gainToAudio';
+import { compressorHandler }       from './nodes/compressor';
+import { filterHandler }           from './nodes/filter';
+import { eq3Handler }              from './nodes/eq3';
+import { multibandSplitHandler }   from './nodes/multibandSplit';
+import { analyserHandler }         from './nodes/analyser';
+import { followerHandler }         from './nodes/follower';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -132,3 +138,9 @@ nodeRegistry.register('abs',              absHandler);
 nodeRegistry.register('negate',           negateHandler);
 nodeRegistry.register('audioToGain',      audioToGainHandler);
 nodeRegistry.register('gainToAudio',      gainToAudioHandler);
+nodeRegistry.register('compressor',       compressorHandler);
+nodeRegistry.register('filter',           filterHandler);
+nodeRegistry.register('eq3',              eq3Handler);
+nodeRegistry.register('multibandSplit',   multibandSplitHandler);
+nodeRegistry.register('analyser',         analyserHandler);
+nodeRegistry.register('follower',         followerHandler);

--- a/src/audio/nodes/analyser.ts
+++ b/src/audio/nodes/analyser.ts
@@ -1,0 +1,42 @@
+import { Analyser } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { AnalyserNodeData } from '../../store/dawTypes';
+
+function getEntry(id: string) {
+	const e = _audioNodes.get(id);
+	return e?.kind === 'analyser' ? e : undefined;
+}
+
+export const analyserHandler: NodeTypeHandler<AnalyserNodeData> = {
+	defaultData: { label: 'Analyser', size: 1024, type: 'fft', smoothing: 0.8 },
+
+	create(id, data) {
+		const toneNode = new Analyser(data.type, data.size);
+		toneNode.smoothing = data.smoothing;
+		_audioNodes.set(id, { kind: 'analyser', toneNode });
+	},
+
+	dispose(id) {
+		const e = getEntry(id);
+		if (!e) return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = getEntry(id);
+		if (!e) return;
+		if (update.size      !== undefined) e.toneNode.size      = update.size;
+		if (update.type      !== undefined) e.toneNode.type      = update.type;
+		if (update.smoothing !== undefined) e.toneNode.smoothing = update.smoothing;
+	},
+};
+
+/** Live-polled readout — FFT bins or waveform samples depending on `type`. Single channel, so always a plain Float32Array. */
+export function getAnalyserValue(id: string): Float32Array | null {
+	const e = getEntry(id);
+	if (!e) return null;
+	const v = e.toneNode.getValue();
+	return Array.isArray(v) ? (v[0] ?? null) : v;
+}

--- a/src/audio/nodes/compressor.ts
+++ b/src/audio/nodes/compressor.ts
@@ -1,0 +1,36 @@
+import { Compressor } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { CompressorNodeData } from '../../store/dawTypes';
+
+export const compressorHandler: NodeTypeHandler<CompressorNodeData> = {
+	defaultData: { label: 'Compressor', threshold: -24, ratio: 12, attack: 0.003, release: 0.25, knee: 30 },
+
+	create(id, data) {
+		const toneNode = new Compressor({
+			threshold: data.threshold,
+			ratio:     data.ratio,
+			attack:    data.attack,
+			release:   data.release,
+			knee:      data.knee,
+		});
+		_audioNodes.set(id, { kind: 'compressor', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'compressor') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'compressor') return;
+		if (update.threshold !== undefined) e.toneNode.threshold.value = update.threshold;
+		if (update.ratio     !== undefined) e.toneNode.ratio.value     = update.ratio;
+		if (update.attack    !== undefined) e.toneNode.attack.value    = update.attack;
+		if (update.release   !== undefined) e.toneNode.release.value   = update.release;
+		if (update.knee      !== undefined) e.toneNode.knee.value      = update.knee;
+	},
+};

--- a/src/audio/nodes/eq3.ts
+++ b/src/audio/nodes/eq3.ts
@@ -1,0 +1,36 @@
+import { EQ3 } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { EQ3NodeData } from '../../store/dawTypes';
+
+export const eq3Handler: NodeTypeHandler<EQ3NodeData> = {
+	defaultData: { label: 'EQ3', low: 0, mid: 0, high: 0, lowFrequency: 400, highFrequency: 2500 },
+
+	create(id, data) {
+		const toneNode = new EQ3({
+			low:           data.low,
+			mid:           data.mid,
+			high:          data.high,
+			lowFrequency:  data.lowFrequency,
+			highFrequency: data.highFrequency,
+		});
+		_audioNodes.set(id, { kind: 'eq3', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'eq3') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'eq3') return;
+		if (update.low           !== undefined) e.toneNode.low.value           = update.low;
+		if (update.mid           !== undefined) e.toneNode.mid.value           = update.mid;
+		if (update.high          !== undefined) e.toneNode.high.value          = update.high;
+		if (update.lowFrequency  !== undefined) e.toneNode.lowFrequency.value  = update.lowFrequency;
+		if (update.highFrequency !== undefined) e.toneNode.highFrequency.value = update.highFrequency;
+	},
+};

--- a/src/audio/nodes/filter.ts
+++ b/src/audio/nodes/filter.ts
@@ -1,0 +1,38 @@
+import { Filter } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { FilterNodeData } from '../../store/dawTypes';
+
+export const filterHandler: NodeTypeHandler<FilterNodeData> = {
+	defaultData: { label: 'Filter', frequency: 350, type: 'lowpass', rolloff: -12, Q: 1, detune: 0, gain: 0 },
+
+	create(id, data) {
+		const toneNode = new Filter({
+			frequency: data.frequency,
+			type:      data.type,
+			rolloff:   data.rolloff,
+			Q:         data.Q,
+			detune:    data.detune,
+			gain:      data.gain,
+		});
+		_audioNodes.set(id, { kind: 'filter', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'filter') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'filter') return;
+		if (update.frequency !== undefined) e.toneNode.frequency.value = update.frequency;
+		if (update.detune    !== undefined) e.toneNode.detune.value    = update.detune;
+		if (update.Q         !== undefined) e.toneNode.Q.value         = update.Q;
+		if (update.gain      !== undefined) e.toneNode.gain.value      = update.gain;
+		if (update.type      !== undefined) e.toneNode.type            = update.type;
+		if (update.rolloff   !== undefined) e.toneNode.rolloff         = update.rolloff;
+	},
+};

--- a/src/audio/nodes/follower.ts
+++ b/src/audio/nodes/follower.ts
@@ -1,0 +1,26 @@
+import { Follower } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { FollowerNodeData } from '../../store/dawTypes';
+
+export const followerHandler: NodeTypeHandler<FollowerNodeData> = {
+	defaultData: { label: 'Follower', smoothing: 0.05 },
+
+	create(id, data) {
+		const toneNode = new Follower(data.smoothing);
+		_audioNodes.set(id, { kind: 'follower', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'follower') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'follower') return;
+		if (update.smoothing !== undefined) e.toneNode.smoothing = update.smoothing;
+	},
+};

--- a/src/audio/nodes/multibandSplit.ts
+++ b/src/audio/nodes/multibandSplit.ts
@@ -1,0 +1,32 @@
+import { MultibandSplit } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { MultibandSplitNodeData } from '../../store/dawTypes';
+
+export const multibandSplitHandler: NodeTypeHandler<MultibandSplitNodeData> = {
+	defaultData: { label: 'MultibandSplit', lowFrequency: 400, highFrequency: 2500, Q: 1 },
+
+	create(id, data) {
+		const toneNode = new MultibandSplit({
+			lowFrequency:  data.lowFrequency,
+			highFrequency: data.highFrequency,
+			Q:             data.Q,
+		});
+		_audioNodes.set(id, { kind: 'multibandSplit', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandSplit') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandSplit') return;
+		if (update.lowFrequency  !== undefined) e.toneNode.lowFrequency.value  = update.lowFrequency;
+		if (update.highFrequency !== undefined) e.toneNode.highFrequency.value = update.highFrequency;
+		if (update.Q             !== undefined) e.toneNode.Q.value             = update.Q;
+	},
+};

--- a/src/audio/nodes/stub.ts
+++ b/src/audio/nodes/stub.ts
@@ -2,7 +2,7 @@ import type { NodeTypeHandler } from './nodeHandler';
 import type { StubNodeData } from '../../store/dawTypes';
 
 export const stubHandler: NodeTypeHandler<StubNodeData> = {
-	defaultData: { label: 'Stub', kind: 'filter' },
+	defaultData: { label: 'Stub', kind: 'panner' },
 	create()        { /* not yet implemented */ },
 	dispose()       { /* not yet implemented */ },
 	setAudioParam() { /* not yet implemented */ },

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -87,16 +87,22 @@ import { AutoPannerNode }         from './nodes/effects/AutoPannerNode';
 import { AutoWahNode }            from './nodes/effects/AutoWahNode';
 import { LimiterNode }            from './nodes/dynamics/LimiterNode';
 import { GateNode }               from './nodes/dynamics/GateNode';
+import { CompressorNode }         from './nodes/dynamics/CompressorNode';
 import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
+import { FilterNode }             from './nodes/processing/FilterNode';
+import { EQ3Node }                from './nodes/processing/EQ3Node';
 import { PanVolNode }             from './nodes/processing/PanVolNode';
 import { SplitNode }              from './nodes/processing/SplitNode';
 import { MergeNode }              from './nodes/processing/MergeNode';
 import { MonoNode }               from './nodes/processing/MonoNode';
 import { VolumeNode }             from './nodes/processing/VolumeNode';
+import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
 import { WaveformNode }           from './nodes/analysis/WaveformNode';
+import { AnalyserNode }           from './nodes/analysis/AnalyserNode';
+import { FollowerNode }           from './nodes/analysis/FollowerNode';
 import { SignalNode }             from './nodes/signal/SignalNode';
 import { ScaleNode }              from './nodes/signal/ScaleNode';
 import { ScaleExpNode }           from './nodes/signal/ScaleExpNode';
@@ -150,16 +156,22 @@ const nodeTypes = {
 	autoWah:          AutoWahNode,
 	limiter:          LimiterNode,
 	gate:             GateNode,
+	compressor:       CompressorNode,
 	biquadFilter:     BiquadFilterNode,
+	filter:           FilterNode,
+	eq3:              EQ3Node,
 	panVol:           PanVolNode,
 	split:            SplitNode,
 	merge:            MergeNode,
 	mono:             MonoNode,
 	volume:           VolumeNode,
+	multibandSplit:   MultibandSplitNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,
 	waveform:         WaveformNode,
+	analyser:         AnalyserNode,
+	follower:         FollowerNode,
 	signal:           SignalNode,
 	scale:            ScaleNode,
 	scaleExp:         ScaleExpNode,

--- a/src/daw/nodes/analysis/AnalyserNode.tsx
+++ b/src/daw/nodes/analysis/AnalyserNode.tsx
@@ -4,23 +4,23 @@ import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import { useDawStore } from '../../../store/daw';
-import { getFFTValue } from '../../../audio/engine';
+import { getAnalyserValue } from '../../../audio/engine';
 import { NodeHeader } from '../shared/NodeHeader';
 import { NODE_COLORS } from '../shared/nodeColors';
 import { GRID_UNIT } from '../shared/gridSystem';
 import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx, HW_INSET } from '../shared/hwStyles';
-import { HwSwitch } from '../shared/hwComponents';
 import { useCanvasReadout } from '../shared/useCanvasReadout';
 import { HwArcSlider } from '../../../components/hw/HwArcSlider';
-import { ANALYSIS_SIZE_OPTIONS, type FFTFlowNode } from '../../../store/dawTypes';
+import { ANALYSIS_SIZE_OPTIONS, type AnalyserFlowNode, type AnalyserType } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.utility;
 const CANVAS_W = 176;
 const CANVAS_H = 48;
+const ANALYSER_TYPES: AnalyserType[] = ['fft', 'waveform'];
 
-export const FFTNode = memo(function FFTNode({ id, data, selected }: NodeProps<FFTFlowNode>) {
+export const AnalyserNode = memo(function AnalyserNode({ id, data, selected }: NodeProps<AnalyserFlowNode>) {
 	const setNodeParam = useDawStore(s => s.setNodeParam);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const sx = useMemo(() => ({
@@ -30,37 +30,57 @@ export const FFTNode = memo(function FFTNode({ id, data, selected }: NodeProps<F
 	}), []);
 
 	useCanvasReadout(canvasRef, CANVAS_W, CANVAS_H, ctx => {
-		const bins = getFFTValue(id);
-		if (!bins) return;
-		const lo = data.normalRange ? 0 : -100;
-		const hi = data.normalRange ? 1 : 0;
-		const barW = CANVAS_W / bins.length;
-		ctx.fillStyle = color;
-		for (let i = 0; i < bins.length; i++) {
-			const norm = Math.max(0, Math.min(1, (bins[i] - lo) / (hi - lo)));
-			const h = norm * CANVAS_H;
-			ctx.fillRect(i * barW, CANVAS_H - h, Math.max(1, barW - 1), h);
+		const values = getAnalyserValue(id);
+		if (!values) return;
+
+		if (data.type === 'waveform') {
+			ctx.strokeStyle = color;
+			ctx.lineWidth = 1;
+			ctx.beginPath();
+			const step = CANVAS_W / values.length;
+			for (let i = 0; i < values.length; i++) {
+				const x = i * step;
+				const y = (1 - (values[i] + 1) / 2) * CANVAS_H;
+				if (i === 0) ctx.moveTo(x, y);
+				else ctx.lineTo(x, y);
+			}
+			ctx.stroke();
+		} else {
+			const barW = CANVAS_W / values.length;
+			ctx.fillStyle = color;
+			for (let i = 0; i < values.length; i++) {
+				const norm = Math.max(0, Math.min(1, (values[i] + 100) / 100));
+				const h = norm * CANVAS_H;
+				ctx.fillRect(i * barW, CANVAS_H - h, Math.max(1, barW - 1), h);
+			}
 		}
 	});
 
 	return (
 		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
-			<NodeHeader id={id} label='FFT' selected={selected} accentColor={color} filledHeader />
+			<NodeHeader id={id} label='Analyser' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
 				<Box sx={{ ...HW_INSET, p: 0.5 }}>
 					<canvas ref={canvasRef} width={CANVAS_W} height={CANVAS_H} style={{ display: 'block', width: '100%', height: CANVAS_H }} />
 				</Box>
-				<Select value={data.size} onChange={e => setNodeParam(id, { size: Number(e.target.value) })} fullWidth
-					sx={sx.select} MenuProps={sx.selectMenu}>
-					{ANALYSIS_SIZE_OPTIONS.map(s => (
-						<MenuItem key={s} value={s} sx={sx.menuItem}>{s}</MenuItem>
-					))}
-				</Select>
+				<Box sx={{ display: 'flex', gap: 0.75 }}>
+					<Select value={data.type} onChange={e => setNodeParam(id, { type: e.target.value as AnalyserType })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{ANALYSER_TYPES.map(t => (
+							<MenuItem key={t} value={t} sx={sx.menuItem}>{t}</MenuItem>
+						))}
+					</Select>
+					<Select value={data.size} onChange={e => setNodeParam(id, { size: Number(e.target.value) })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{ANALYSIS_SIZE_OPTIONS.map(s => (
+							<MenuItem key={s} value={s} sx={sx.menuItem}>{s}</MenuItem>
+						))}
+					</Select>
+				</Box>
 				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
 					<HwArcSlider label='smoothing' value={data.smoothing} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { smoothing: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
 				</Box>
-				<HwSwitch checked={data.normalRange} color={color} onChange={() => setNodeParam(id, { normalRange: !data.normalRange })} label='normal range' />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/analysis/FollowerNode.tsx
+++ b/src/daw/nodes/analysis/FollowerNode.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { FollowerFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.utility;
+
+export const FollowerNode = memo(function FollowerNode({ id, data, selected }: NodeProps<FollowerFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Follower' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='smoothing' value={data.smoothing} min={0.001} max={1} step={0.001} color={color} onChange={v => setNodeParam(id, { smoothing: v })} format={v => v.toFixed(3)} unit='s' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/analysis/WaveformNode.tsx
+++ b/src/daw/nodes/analysis/WaveformNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useMemo, useRef } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
@@ -11,6 +11,7 @@ import { GRID_UNIT } from '../shared/gridSystem';
 import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx, HW_INSET } from '../shared/hwStyles';
+import { useCanvasReadout } from '../shared/useCanvasReadout';
 import { ANALYSIS_SIZE_OPTIONS, type WaveformFlowNode } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.utility;
@@ -20,39 +21,27 @@ const CANVAS_H = 48;
 export const WaveformNode = memo(function WaveformNode({ id, data, selected }: NodeProps<WaveformFlowNode>) {
 	const setNodeParam = useDawStore(s => s.setNodeParam);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
-	const rafRef = useRef<number>(0);
 	const sx = useMemo(() => ({
 		select:     hwSelectSx(color, 'small'),
 		selectMenu: hwSelectMenuProps(color),
 		menuItem:   hwMenuItemSx(color),
 	}), []);
 
-	useEffect(() => {
-		const draw = () => {
-			const canvas  = canvasRef.current;
-			const samples = getWaveformValue(id);
-			if (canvas && samples) {
-				const ctx = canvas.getContext('2d');
-				if (ctx) {
-					ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
-					ctx.strokeStyle = color;
-					ctx.lineWidth = 1;
-					ctx.beginPath();
-					const step = CANVAS_W / samples.length;
-					for (let i = 0; i < samples.length; i++) {
-						const x = i * step;
-						const y = (1 - (samples[i] + 1) / 2) * CANVAS_H;
-						if (i === 0) ctx.moveTo(x, y);
-						else ctx.lineTo(x, y);
-					}
-					ctx.stroke();
-				}
-			}
-			rafRef.current = requestAnimationFrame(draw);
-		};
-		rafRef.current = requestAnimationFrame(draw);
-		return () => cancelAnimationFrame(rafRef.current);
-	}, [id]);
+	useCanvasReadout(canvasRef, CANVAS_W, CANVAS_H, ctx => {
+		const samples = getWaveformValue(id);
+		if (!samples) return;
+		ctx.strokeStyle = color;
+		ctx.lineWidth = 1;
+		ctx.beginPath();
+		const step = CANVAS_W / samples.length;
+		for (let i = 0; i < samples.length; i++) {
+			const x = i * step;
+			const y = (1 - (samples[i] + 1) / 2) * CANVAS_H;
+			if (i === 0) ctx.moveTo(x, y);
+			else ctx.lineTo(x, y);
+		}
+		ctx.stroke();
+	});
 
 	return (
 		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>

--- a/src/daw/nodes/dynamics/CompressorNode.tsx
+++ b/src/daw/nodes/dynamics/CompressorNode.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { CompressorFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.dynamics;
+
+export const CompressorNode = memo(function CompressorNode({ id, data, selected }: NodeProps<CompressorFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Compressor' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='threshold' value={data.threshold} min={-100} max={0}  step={1}    color={color} onChange={v => setNodeParam(id, { threshold: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='ratio'     value={data.ratio}     min={1}    max={20} step={0.5}  color={color} onChange={v => setNodeParam(id, { ratio: v })}     format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='attack'    value={data.attack}    min={0}    max={1}  step={0.001} color={color} onChange={v => setNodeParam(id, { attack: v })}   format={v => v.toFixed(3)} unit='s'  allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='release'   value={data.release}   min={0}    max={1}  step={0.01}  color={color} onChange={v => setNodeParam(id, { release: v })}  format={v => v.toFixed(2)} unit='s'  allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='knee'      value={data.knee}      min={0}    max={40} step={1}     color={color} onChange={v => setNodeParam(id, { knee: v })}     format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/EQ3Node.tsx
+++ b/src/daw/nodes/processing/EQ3Node.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { EQ3FlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+
+export const EQ3Node = memo(function EQ3Node({ id, data, selected }: NodeProps<EQ3FlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='EQ3' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='low'      value={data.low}           min={-40} max={40}   step={0.5} color={color} onChange={v => setNodeParam(id, { low: v })}           format={v => v.toFixed(1)}          unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='mid'      value={data.mid}           min={-40} max={40}   step={0.5} color={color} onChange={v => setNodeParam(id, { mid: v })}           format={v => v.toFixed(1)}          unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='high'     value={data.high}          min={-40} max={40}   step={0.5} color={color} onChange={v => setNodeParam(id, { high: v })}          format={v => v.toFixed(1)}          unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='low freq' value={data.lowFrequency}  min={20}  max={2000}  step={10}  color={color} onChange={v => setNodeParam(id, { lowFrequency: v })}  format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='hi freq'  value={data.highFrequency} min={200} max={20000} step={10}  color={color} onChange={v => setNodeParam(id, { highFrequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/FilterNode.tsx
+++ b/src/daw/nodes/processing/FilterNode.tsx
@@ -1,0 +1,60 @@
+import { memo, useMemo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx } from '../shared/hwStyles';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import { FILTER_ROLLOFF_OPTIONS, type FilterFlowNode, type BiquadFilterType, type FilterRolloff } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const FILTER_TYPES: BiquadFilterType[] = [
+	'lowpass', 'highpass', 'bandpass', 'lowshelf', 'highshelf', 'notch', 'allpass', 'peaking',
+];
+
+export const FilterNode = memo(function FilterNode({ id, data, selected }: NodeProps<FilterFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const sx = useMemo(() => ({
+		select:     hwSelectSx(color, 'small'),
+		selectMenu: hwSelectMenuProps(color),
+		menuItem:   hwMenuItemSx(color),
+	}), []);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Filter' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Box sx={{ display: 'flex', gap: 0.75 }}>
+					<Select value={data.type} onChange={e => setNodeParam(id, { type: e.target.value as BiquadFilterType })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{FILTER_TYPES.map(t => (
+							<MenuItem key={t} value={t} sx={sx.menuItem}>{t}</MenuItem>
+						))}
+					</Select>
+					<Select value={data.rolloff} onChange={e => setNodeParam(id, { rolloff: Number(e.target.value) as FilterRolloff })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{FILTER_ROLLOFF_OPTIONS.map(r => (
+							<MenuItem key={r} value={r} sx={sx.menuItem}>{r}dB/oct</MenuItem>
+						))}
+					</Select>
+				</Box>
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'   value={data.frequency} min={20}    max={20000} step={10}   color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='Q'      value={data.Q}         min={0.001} max={100}   step={0.1}  color={color} onChange={v => setNodeParam(id, { Q: v })}         format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='detune' value={data.detune}    min={-1200} max={1200}  step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}    format={v => String(Math.round(v))}  unit='ct' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='gain'   value={data.gain}      min={-40}   max={40}    step={0.5}  color={color} onChange={v => setNodeParam(id, { gain: v })}      format={v => v.toFixed(1)}           unit='dB' allowValueEdit allowBoundsEdit />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/MultibandSplitNode.tsx
+++ b/src/daw/nodes/processing/MultibandSplitNode.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader, NODE_HEADER_HEIGHT } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, bottomOutputHandleStyle, outputLabel } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { MultibandSplitFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const INPUT_TOP = `calc(${NODE_HEADER_HEIGHT}px + 20px)`;
+
+export const MultibandSplitNode = memo(function MultibandSplitNode({ id, data, selected }: NodeProps<MultibandSplitFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', pb: 2.5, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='MultibandSplit' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='low freq' value={data.lowFrequency}  min={20}  max={2000}  step={10}  color={color} onChange={v => setNodeParam(id, { lowFrequency: v })}  format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='hi freq'  value={data.highFrequency} min={200} max={20000} step={10}  color={color} onChange={v => setNodeParam(id, { highFrequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='Q'        value={data.Q}             min={0.1} max={10}    step={0.1} color={color} onChange={v => setNodeParam(id, { Q: v })}             format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left} id='in-0' style={{ ...inputHandleStyle(color), top: INPUT_TOP }} />
+
+			<Handle type='source' position={Position.Bottom} id='out-0' style={{ ...bottomOutputHandleStyle(color), left: '25%' }} />
+			{outputLabel('low', color, '25%')}
+			<Handle type='source' position={Position.Bottom} id='out-1' style={{ ...bottomOutputHandleStyle(color), left: '50%' }} />
+			{outputLabel('mid', color, '50%')}
+			<Handle type='source' position={Position.Bottom} id='out-2' style={{ ...bottomOutputHandleStyle(color), left: '75%' }} />
+			{outputLabel('high', color, '75%')}
+		</Box>
+	);
+});

--- a/src/daw/nodes/shared/StubNode.tsx
+++ b/src/daw/nodes/shared/StubNode.tsx
@@ -13,7 +13,6 @@ import type { StubFlowNode, StubKind } from '../../../store/dawTypes';
 const STUB_TOPOLOGY: Partial<Record<StubKind, { inputs: string[]; outputs: string[] }>> = {
 	noiseGenerator: { inputs: [],               outputs: ['out-0'] },
 	panner:         { inputs: ['in-0'],         outputs: ['out-0', 'out-1'] },
-	multibandSplit: { inputs: ['in-0'],         outputs: ['out-0', 'out-1', 'out-2'] },
 	crossFade:      { inputs: ['in-0', 'in-1'], outputs: ['out-0'] },
 	// Source-like stubs (instruments, oscillators) have no audio input
 	synth:          { inputs: [], outputs: ['out-0'] },

--- a/src/daw/nodes/shared/useCanvasReadout.ts
+++ b/src/daw/nodes/shared/useCanvasReadout.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * Drives a requestAnimationFrame loop that clears a canvas and hands its 2D
+ * context to `draw` every frame. `draw` is read from a ref so the loop never
+ * restarts on re-render — only `width`/`height` changes tear it down and
+ * restart it, matching ADR-0001's scope: the FFT/Waveform/Analyser rendering
+ * shape, not the setInterval+React-state shape Meter/DCMeter use.
+ */
+export function useCanvasReadout(
+	canvasRef: RefObject<HTMLCanvasElement | null>,
+	width:     number,
+	height:    number,
+	draw:      (ctx: CanvasRenderingContext2D) => void,
+): void {
+	const drawRef = useRef(draw);
+	drawRef.current = draw;
+
+	useEffect(() => {
+		const rafRef = { current: 0 };
+		const tick = () => {
+			const canvas = canvasRef.current;
+			const ctx    = canvas?.getContext('2d');
+			if (ctx) {
+				ctx.clearRect(0, 0, width, height);
+				drawRef.current(ctx);
+			}
+			rafRef.current = requestAnimationFrame(tick);
+		};
+		rafRef.current = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(rafRef.current);
+	}, [canvasRef, width, height]);
+}

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -479,6 +479,12 @@ const REAL_ACTIONS = new Set<string>([
 	'negate',
 	'audioToGain',
 	'gainToAudio',
+	'compressor',
+	'filter',
+	'eq3',
+	'multibandSplit',
+	'analyser',
+	'follower',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -112,7 +112,6 @@ const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
 	crossFade:           'CrossFade',
-	multibandSplit:      'MultibandSplit',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
 	waveShaper:          'WaveShaper',

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -36,7 +36,7 @@ export type GainNodeData = {
 
 export type StubKind =
 	// — existing processing stubs (not yet implemented) —
-	| 'filter' | 'compressor' | 'noiseGenerator' | 'panner'
+	| 'noiseGenerator' | 'panner'
 	// — Source / Instrument —
 	| 'omniOscillator'
 	| 'players' | 'userMedia'
@@ -45,10 +45,10 @@ export type StubKind =
 	// — Dynamics —
 	| 'midSideCompressor' | 'multibandCompressor'
 	// — Processing —
-	| 'eq3' | 'channel' | 'panner3d' | 'crossFade'
-	| 'multibandSplit' | 'solo' | 'convolver'
+	| 'channel' | 'panner3d' | 'crossFade'
+	| 'solo' | 'convolver'
 	// — Analysis —
-	| 'analyser' | 'follower' | 'recorder'
+	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
 	// — Signal —
 	| 'waveShaper' | 'add' | 'multiply' | 'greaterThan'
@@ -341,9 +341,21 @@ export type GateNodeData = {
 };
 export type GateFlowNode = Node<GateNodeData, 'gate'>;
 
+export type CompressorNodeData = {
+	label:     string;
+	threshold: number;   // dB, -100–0, default -24
+	ratio:     number;   // 1–20, default 12
+	attack:    number;   // seconds, 0–1, default 0.003
+	release:   number;   // seconds, 0–1, default 0.25
+	knee:      number;   // dB, 0–40, default 30
+};
+export type CompressorFlowNode = Node<CompressorNodeData, 'compressor'>;
+
 // ─── Processing node data types ───────────────────────────────────────────────
 
 export type BiquadFilterType = 'lowpass' | 'highpass' | 'bandpass' | 'lowshelf' | 'highshelf' | 'notch' | 'allpass' | 'peaking';
+export const FILTER_ROLLOFF_OPTIONS = [-12, -24, -48, -96] as const;
+export type FilterRolloff = typeof FILTER_ROLLOFF_OPTIONS[number];
 
 export type BiquadFilterNodeData = {
 	label:     string;
@@ -354,6 +366,27 @@ export type BiquadFilterNodeData = {
 	gain:      number;           // dB, -40–40, default 0 (lowshelf/highshelf/peaking only)
 };
 export type BiquadFilterFlowNode = Node<BiquadFilterNodeData, 'biquadFilter'>;
+
+export type FilterNodeData = {
+	label:     string;
+	frequency: number;           // Hz, 20–20000, default 350
+	type:      BiquadFilterType; // default 'lowpass'
+	rolloff:   FilterRolloff;    // default -12
+	Q:         number;           // 0.001–100, default 1
+	detune:    number;           // cents, -1200–1200, default 0
+	gain:      number;           // dB, -40–40, default 0 (lowshelf/highshelf/peaking only)
+};
+export type FilterFlowNode = Node<FilterNodeData, 'filter'>;
+
+export type EQ3NodeData = {
+	label:         string;
+	low:           number;   // dB, -40–40, default 0
+	mid:           number;   // dB, -40–40, default 0
+	high:          number;   // dB, -40–40, default 0
+	lowFrequency:  number;   // Hz, 20–2000, default 400
+	highFrequency: number;   // Hz, 200–20000, default 2500
+};
+export type EQ3FlowNode = Node<EQ3NodeData, 'eq3'>;
 
 export type PanVolNodeData = {
 	label:  string;
@@ -379,10 +412,18 @@ export type VolumeNodeData = {
 };
 export type VolumeFlowNode = Node<VolumeNodeData, 'volume'>;
 
+export type MultibandSplitNodeData = {
+	label:         string;
+	lowFrequency:  number;   // Hz, 20–2000, default 400
+	highFrequency: number;   // Hz, 200–20000, default 2500
+	Q:             number;   // 0.1–10, default 1
+};
+export type MultibandSplitFlowNode = Node<MultibandSplitNodeData, 'multibandSplit'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
-// getFFTValue/getMeterValue/getDCMeterValue/getWaveformValue.
+// getFFTValue/getMeterValue/getDCMeterValue/getWaveformValue/getAnalyserValue.
 
 export const ANALYSIS_SIZE_OPTIONS = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384] as const;
 export type AnalysisSize = typeof ANALYSIS_SIZE_OPTIONS[number];
@@ -410,6 +451,24 @@ export type WaveformNodeData = {
 	size:  AnalysisSize;   // power of two, default 1024
 };
 export type WaveformFlowNode = Node<WaveformNodeData, 'waveform'>;
+
+export type AnalyserType = 'fft' | 'waveform';
+
+export type AnalyserNodeData = {
+	label:     string;
+	size:      AnalysisSize;   // power of two, default 1024
+	type:      AnalyserType;   // default 'fft'
+	smoothing: number;         // 0–1, default 0.8
+};
+export type AnalyserFlowNode = Node<AnalyserNodeData, 'analyser'>;
+
+// Follower is not a tap despite living in the Analysis catalogue bucket — it's
+// a real processor (in-0 → out-0, no readout): see docs/node-roadmap.md.
+export type FollowerNodeData = {
+	label:     string;
+	smoothing: number;   // seconds, 0.001–1, default 0.05
+};
+export type FollowerFlowNode = Node<FollowerNodeData, 'follower'>;
 
 // ─── Signal node data types ────────────────────────────────────────────────────
 
@@ -486,16 +545,22 @@ export type AppNode =
 	| AutoWahFlowNode
 	| LimiterFlowNode
 	| GateFlowNode
+	| CompressorFlowNode
 	| BiquadFilterFlowNode
+	| FilterFlowNode
+	| EQ3FlowNode
 	| PanVolFlowNode
 	| SplitFlowNode
 	| MergeFlowNode
 	| MonoFlowNode
 	| VolumeFlowNode
+	| MultibandSplitFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
 	| WaveformFlowNode
+	| AnalyserFlowNode
+	| FollowerFlowNode
 	| SignalFlowNode
 	| ScaleFlowNode
 	| ScaleExpFlowNode
@@ -635,16 +700,22 @@ export type AutoWahAudioEntry         = { kind: 'autoWah';          toneNode: Au
 
 export type LimiterAudioEntry     = { kind: 'limiter';     toneNode: Limiter };
 export type GateAudioEntry        = { kind: 'gate';        toneNode: Gate };
+export type CompressorAudioEntry  = { kind: 'compressor';  toneNode: Compressor };
 export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFilter };
+export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
+export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
 export type PanVolAudioEntry      = { kind: 'panVol';      toneNode: PanVol };
 export type SplitNodeAudioEntry   = { kind: 'split';       toneNode: Split };
 export type MergeNodeAudioEntry   = { kind: 'merge';       toneNode: Merge };
 export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
 export type VolumeAudioEntry      = { kind: 'volume';      toneNode: Volume };
+export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: MultibandSplit };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
 export type WaveformAudioEntry    = { kind: 'waveform';    toneNode: Waveform };
+export type AnalyserAudioEntry    = { kind: 'analyser';    toneNode: Analyser };
+export type FollowerAudioEntry    = { kind: 'follower';    toneNode: Follower };
 export type SignalNodeAudioEntry  = { kind: 'signal';      toneNode: Signal<'number'> };
 export type ScaleAudioEntry       = { kind: 'scale';       toneNode: Scale };
 export type ScaleExpAudioEntry    = { kind: 'scaleExp';    toneNode: ScaleExp };
@@ -692,16 +763,22 @@ export type AudioNodeEntry =
 	| AutoWahAudioEntry
 	| LimiterAudioEntry
 	| GateAudioEntry
+	| CompressorAudioEntry
 	| BiquadFilterAudioEntry
+	| FilterAudioEntry
+	| EQ3AudioEntry
 	| PanVolAudioEntry
 	| SplitNodeAudioEntry
 	| MergeNodeAudioEntry
 	| MonoAudioEntry
 	| VolumeAudioEntry
+	| MultibandSplitAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry
 	| WaveformAudioEntry
+	| AnalyserAudioEntry
+	| FollowerAudioEntry
 	| SignalNodeAudioEntry
 	| ScaleAudioEntry
 	| ScaleExpAudioEntry


### PR DESCRIPTION
## Summary
- First implementation batch of Tier 2 nodes (`docs/node-roadmap.md`), per the risk-based batching plan from `docs/adr/` (grilled before this PR): the 6 routine nodes with no new architecture, held back from Solo/Convolver/Add-Multiply-GreaterThan which each need their own batch.
- **Dynamics**: Compressor
- **Processing**: Filter, EQ3, MultibandSplit (needed a custom `audioCore.ts` routing adapter — its `output` is `undefined` on the Tone.js class, `out-0/1/2` select the low/mid/high child `Filter` instances directly)
- **Analysis**: Analyser (introduces `useCanvasReadout`, the shared rAF+canvas hook from ADR-0001; also used to refactor FFTNode/WaveformNode off their duplicated rAF-loop boilerplate), Follower (a real processor despite living in the Analysis catalogue bucket — no readout, per the roadmap's note)
- Each node follows the existing `NodeTypeHandler`/`nodeRegistry`/`AddNodePanel` pattern; removed the six kinds from `StubKind` now that they're real

## Test plan
- [x] `npx tsc --noEmit` — no new errors (17 pre-existing MUI `MenuProps`/`color` typing-debt errors reproduced faithfully by following established, already-broken patterns; not regressions)
- [x] `npm run build` — passes clean
- [ ] Manual smoke test in a running dev server (add each of the 6 nodes, wire them into a chain, confirm no console errors)