### PR TITLE
Record ADRs for Tier 3 node buildout decisions

### DIFF
--- a/docs/adr/0004-nested-param-panel-layout.md
+++ b/docs/adr/0004-nested-param-panel-layout.md
@@ -1,0 +1,15 @@
+# Nested param panels: side-by-side bands, not tabs
+
+MidSideCompressor and MultibandCompressor are reactoscope's first nodes whose Tone.js params
+naturally split into multiple named groups (mid/side, or low/mid/high bands) rather than one flat
+list — every existing node UI is a single column of sliders/dropdowns. We're rendering each band
+as its own labeled sub-panel, all shown side-by-side and always visible, rather than behind a tab
+switcher that reveals one band at a time. Tabs would keep the node body narrower, but every other
+node in the catalogue is direct-manipulation — every control is visible and editable without
+clicking through anything first — and hiding two-thirds of a node's params behind tabs would be
+the first departure from that. The node just gets wider instead, consistent with existing
+precedent (nodes already scale width by param count, e.g. FFT/BiquadFilter at 2.5× the grid unit).
+
+Each band reuses a new shared `CompressorControls` component (extracted from
+`CompressorNode.tsx`'s existing threshold/ratio/attack/release/knee slider row, parameterized by
+value+onChange per param) rather than each node hand-duplicating that row two or three more times.

--- a/docs/adr/0005-waveshaper-preset-driven.md
+++ b/docs/adr/0005-waveshaper-preset-driven.md
@@ -1,0 +1,17 @@
+# WaveShaper ships preset-driven, not a curve editor
+
+Tone.js's `WaveShaper.mapping` is a JS function or raw sample array, not a slider-able value —
+there's no numeric range to expose. v1 ships three named curve presets (identity, soft clip, hard
+clip) via a dropdown, plus a live `oversample` (none/2x/4x) setter. Building an actual curve editor
+(freehand or control-point curve drawing) is out of scope; presets cover the common
+distortion/saturation use case without inventing a new curve-editing UI from scratch.
+
+This establishes a pattern distinct from every other dropdown in the codebase. Filter's `type`
+dropdown, for example, is a live Tone.js `Param`/getter-setter the UI reads back and displays —
+the dropdown's value *is* the persisted state. WaveShaper's dropdown value is just a preset
+*name*, stored in node data purely for serialization/redraw; selecting a preset triggers an
+imperative `setMap()` call rather than setting a watched param directly. Worth recording explicitly
+so a future curve/shape-selection node (there's real precedent coming — Sampler's note-to-buffer
+mapping, Pattern's cycling algorithms) reuses this preset-name-drives-imperative-call shape rather
+than reinventing it, and so a reader diffing this against Filter's dropdown doesn't wonder why
+WaveShaper's "doesn't work like the others."

--- a/docs/adr/0006-recorder-v1-interaction-scope.md
+++ b/docs/adr/0006-recorder-v1-interaction-scope.md
@@ -1,0 +1,25 @@
+# Recorder v1: no live mimeType, no auto-download, own lifecycle functions
+
+Two related cuts to Recorder's v1 interaction, plus one wiring decision:
+
+**No live `mimeType` control.** Tone.js's `Recorder.mimeType` is a read-only getter — it's
+constructor-only, with no setter. A dropdown would mean disposing and recreating the whole
+`toneNode` on every change, the same rebuild machinery `oscillator.ts` and friends use for
+single-use sources. That's real complexity for a param the roadmap itself already called
+low-priority, so v1 skips it entirely: `new Recorder()` with no options, browser default format.
+
+**Persistent Download button, not auto-download.** `stop()` resolves with a `Blob`. Tone.js's own
+documented example immediately builds an anchor element and calls `.click()` on it — an
+instant browser download the moment recording stops. reactoscope shows a Download button plus a
+duration/size readout instead, left for the user to click on their own schedule. Every other
+action in the app is something the user explicitly does; a Stop button that silently triggers an
+OS-level save dialog as a side effect would be the first exception. This also means a user can
+keep the take around and decide whether to keep it before it leaves the browser.
+
+**Own lifecycle functions, not the shared handler protocol.** `startRecording`/`stopRecording`/
+`pauseRecording` live in `src/audio/nodes/recorder.ts` and are called directly by the node's UI
+component, not threaded through `NodeTypeHandler.start`/`stop` — that protocol is reserved for the
+single-use-source recreate-on-restart contract and doesn't fit record/pause/stop-with-blob-result.
+This mirrors existing precedent in `player.ts` (`playNode`/`pauseNode`/`seekNode` etc., called
+directly by `PlayerNode.tsx`, bypassing the generic handler path) rather than inventing a third
+shape.

--- a/docs/adr/0007-channel-send-receive-out-of-scope.md
+++ b/docs/adr/0007-channel-send-receive-out-of-scope.md
@@ -1,0 +1,16 @@
+# Channel's send/receive bus routing is permanently out of scope
+
+`Channel.send(name, volume)` / `receive(name)` let a node route audio to or from a named string
+bus, entirely outside the normal node-graph connection model — the audio actually flows, but no
+edge on the canvas represents it. reactoscope's node graph works on the invariant that every
+connection between two nodes is a visible edge; that's implicit in how the app works today, worth
+stating explicitly here because Channel is the first node whose underlying Tone.js class offers a
+way to break it.
+
+This is a boundary decision, not a v1 scope cut like the param-count reductions elsewhere in Tier
+3 (MultibandCompressor, Panner3D) — those are "less work for now, easy to add more sliders later."
+This one is "no," permanently: exposing send/receive would mean a Channel node could be
+effectively wired to another node with nothing on the canvas showing it, which cuts against the
+whole point of a node-graph UI. If bus routing turns out to be genuinely wanted later, it needs
+its own design as a visible graph concept (a bus node type, say), not a shortcut bolted onto
+Channel's param panel.


### PR DESCRIPTION
## Summary
- Resolved the open Tier 3 design/architecture questions from `docs/node-roadmap.md` via a grilling-skill interview
- Discovered during exploration: Channel depends on Solo's cross-instance mute pattern (ADR-0003), but standalone Solo was never actually built (Tier 2's routine batch shipped; Solo/Convolver/signal-math batches didn't happen yet) — Solo needs to land as its own small batch before Channel
- Recorded four ADRs:
  - `0004-nested-param-panel-layout.md` — MidSideCompressor/MultibandCompressor show band groups side-by-side (not tabs), reusing a new shared `CompressorControls` component
  - `0005-waveshaper-preset-driven.md` — preset dropdown (identity/soft clip/hard clip) driving imperative `setMap()` calls, not a curve editor
  - `0006-recorder-v1-interaction-scope.md` — no live `mimeType` (Tone's getter is constructor-only), persistent Download button not auto-download, own lifecycle functions mirroring `player.ts`'s precedent
  - `0007-channel-send-receive-out-of-scope.md` — permanent graph-model boundary (every connection is a visible edge), not just a v1 cut
- Also decided (not ADR-worthy — same shape as Tier 2's Convolver/Compressor-meter cuts): MultibandCompressor exposes threshold+ratio only per band, Panner3D exposes only position+panningModel — noted for a backlog issue
- Batching order agreed: Solo alone → CrossFade+Panner → MidSideCompressor → MultibandCompressor → Panner3D → WaveShaper → Recorder → Channel

## Test plan
- [ ] N/A — docs only, no code changes