### PR TITLE
Implement Solo: Tier 3 batch 1

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -168,6 +168,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	panVol:           genericAdapter,
 	mono:             genericAdapter,
 	volume:           genericAdapter,
+	solo:             genericAdapter,
 	fft:              genericAdapter,
 	meter:            genericAdapter,
 	dcMeter:          genericAdapter,

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -172,3 +172,4 @@ export { getMeterValue }   from './nodes/meter';
 export { getDCMeterValue } from './nodes/dcMeter';
 export { getWaveformValue } from './nodes/waveform';
 export { getAnalyserValue } from './nodes/analyser';
+export { setSoloed } from './nodes/solo';

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -58,6 +58,7 @@ import { eq3Handler }              from './nodes/eq3';
 import { multibandSplitHandler }   from './nodes/multibandSplit';
 import { analyserHandler }         from './nodes/analyser';
 import { followerHandler }         from './nodes/follower';
+import { soloHandler }             from './nodes/solo';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -144,3 +145,4 @@ nodeRegistry.register('eq3',              eq3Handler);
 nodeRegistry.register('multibandSplit',   multibandSplitHandler);
 nodeRegistry.register('analyser',         analyserHandler);
 nodeRegistry.register('follower',         followerHandler);
+nodeRegistry.register('solo',             soloHandler);

--- a/src/audio/nodes/solo.ts
+++ b/src/audio/nodes/solo.ts
@@ -1,0 +1,35 @@
+import { Solo } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { SoloNodeData } from '../../store/dawTypes';
+
+// Solo has no configurable params exposed through the generic setNodeParam
+// path — which instance is soloed is store-driven (daw.ts's soloedNodeId,
+// ADR-0003), set via setSoloed() below, not through NodeTypeHandler.
+
+export const soloHandler: NodeTypeHandler<SoloNodeData> = {
+	defaultData: { label: 'Solo' },
+
+	create(id) {
+		const toneNode = new Solo();
+		_audioNodes.set(id, { kind: 'solo', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'solo') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam() {
+		// No configurable params — see setSoloed().
+	},
+};
+
+/** Solos or unsolos this instance. Tone's own static registry mutes every other Solo/Channel instance in the context. */
+export function setSoloed(id: string, soloed: boolean): void {
+	const e = _audioNodes.get(id);
+	if (e?.kind !== 'solo') return;
+	e.toneNode.solo = soloed;
+}

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -97,6 +97,7 @@ import { MergeNode }              from './nodes/processing/MergeNode';
 import { MonoNode }               from './nodes/processing/MonoNode';
 import { VolumeNode }             from './nodes/processing/VolumeNode';
 import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
+import { SoloNode }               from './nodes/processing/SoloNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
@@ -166,6 +167,7 @@ const nodeTypes = {
 	mono:             MonoNode,
 	volume:           VolumeNode,
 	multibandSplit:   MultibandSplitNode,
+	solo:             SoloNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,

--- a/src/daw/nodes/processing/SoloNode.tsx
+++ b/src/daw/nodes/processing/SoloNode.tsx
@@ -1,0 +1,33 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwSwitch } from '../shared/hwComponents';
+import type { SoloFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+
+export const SoloNode = memo(function SoloNode({ id, selected }: NodeProps<SoloFlowNode>) {
+	const toggleSolo   = useDawStore(s => s.toggleSolo);
+	const soloedNodeId = useDawStore(s => s.soloedNodeId);
+	const isSoloed      = soloedNodeId === id;
+	const isMutedByPeer = soloedNodeId !== null && !isSoloed;
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 1.5 * GRID_UNIT, position: 'relative', opacity: isMutedByPeer ? 0.55 : 1, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Solo' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwSwitch checked={isSoloed} color={color} onChange={() => toggleSolo(id)} label='solo' />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -485,6 +485,7 @@ const REAL_ACTIONS = new Set<string>([
 	'multibandSplit',
 	'analyser',
 	'follower',
+	'solo',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -160,6 +160,7 @@ type DawState = {
 	selectedNodeId: string | null;
 	sceneRunning:   boolean;
 	playingNodes:   Set<string>;
+	soloedNodeId:   string | null;
 
 	onNodesChange:     OnNodesChange<AppNode>;
 	onEdgesChange:     OnEdgesChange<AppEdge>;
@@ -174,6 +175,7 @@ type DawState = {
 	updateNodeData:      (id: string, data: Partial<Record<string, unknown>>) => void;
 	updateNodePositions: (updatedNodes: AppNode[]) => void;
 	setSelectedNodeId:   (id: string | null) => void;
+	toggleSolo:          (id: string) => void;
 	setSpeakersMuted:    (muted: boolean) => void;
 	edgePathType:        'bezier' | 'straight' | 'step' | 'smoothstep';
 	setEdgePathType:     (type: 'bezier' | 'straight' | 'step' | 'smoothstep') => void;
@@ -191,6 +193,7 @@ export const useDawStore = create<DawState>((set, get) => ({
 	selectedNodeId: null,
 	sceneRunning:   false,
 	playingNodes:   new Set<string>(),
+	soloedNodeId:   null,
 
 	setNodePlaying: (id, playing) => set(state => {
 		const next = new Set(state.playingNodes);
@@ -215,7 +218,11 @@ export const useDawStore = create<DawState>((set, get) => ({
 			set(state => {
 				const next = new Set(state.playingNodes);
 				removed.forEach(id => next.delete(id));
-				return { nodes: applyNodeChanges(changes, state.nodes), playingNodes: next };
+				return {
+					nodes:        applyNodeChanges(changes, state.nodes),
+					playingNodes: next,
+					soloedNodeId: state.soloedNodeId && removed.includes(state.soloedNodeId) ? null : state.soloedNodeId,
+				};
 			});
 		} else {
 			set({ nodes: applyNodeChanges(changes, get().nodes) });
@@ -350,6 +357,21 @@ export const useDawStore = create<DawState>((set, get) => ({
 
 	setSelectedNodeId: (id) => set({ selectedNodeId: id }),
 
+	// Only one Solo/Channel instance can be soloed at a time (Tone.Solo's own
+	// static registry enforces this on the audio side, ADR-0003) — this field
+	// is the UI's mirror of that, letting every Solo node's component dim
+	// itself when a *different* instance is the soloed one.
+	toggleSolo: (id) => {
+		const current = get().soloedNodeId;
+		if (current === id) {
+			engine.setSoloed(id, false);
+			set({ soloedNodeId: null });
+		} else {
+			engine.setSoloed(id, true);
+			set({ soloedNodeId: id });
+		}
+	},
+
 	setSpeakersMuted: (muted) => {
 		engine.setSpeakersMuted(muted);
 		set({
@@ -417,6 +439,7 @@ export const useDawStore = create<DawState>((set, get) => ({
 			sceneRunning:   false,
 			selectedNodeId: null,
 			playingNodes:   new Set<string>(),
+			soloedNodeId:   null,
 		});
 	},
 

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -46,7 +46,7 @@ export type StubKind =
 	| 'midSideCompressor' | 'multibandCompressor'
 	// — Processing —
 	| 'channel' | 'panner3d' | 'crossFade'
-	| 'solo' | 'convolver'
+	| 'convolver'
 	// — Analysis —
 	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
@@ -420,6 +420,12 @@ export type MultibandSplitNodeData = {
 };
 export type MultibandSplitFlowNode = Node<MultibandSplitNodeData, 'multibandSplit'>;
 
+// Whether this instance is soloed is store-driven (daw.ts's soloedNodeId,
+// ADR-0003), not a field here — only one instance can be soloed at a time,
+// so a per-node boolean would just duplicate the store's own truth.
+export type SoloNodeData = { label: string };
+export type SoloFlowNode = Node<SoloNodeData, 'solo'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
@@ -555,6 +561,7 @@ export type AppNode =
 	| MonoFlowNode
 	| VolumeFlowNode
 	| MultibandSplitFlowNode
+	| SoloFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
@@ -710,6 +717,7 @@ export type MergeNodeAudioEntry   = { kind: 'merge';       toneNode: Merge };
 export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
 export type VolumeAudioEntry      = { kind: 'volume';      toneNode: Volume };
 export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: MultibandSplit };
+export type SoloAudioEntry        = { kind: 'solo';        toneNode: Solo };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
@@ -773,6 +781,7 @@ export type AudioNodeEntry =
 	| MonoAudioEntry
 	| VolumeAudioEntry
 	| MultibandSplitAudioEntry
+	| SoloAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry


### PR DESCRIPTION
## Summary
- First Tier 3 implementation batch: standalone `Solo` node, following the batching order agreed in #25
- Finishes pending Tier 2 scope: `Channel` (later in Tier 3) depends on the cross-instance solo pattern ADR-0003 designed, but standalone Solo itself was never built (Tier 2's routine batch shipped without it)
- Tone's own static `Solo` registry handles actual audio muting; `daw.ts` adds a `soloedNodeId: string | null` field as the UI's mirror (not a per-node boolean, which would duplicate the store's truth) plus a `toggleSolo(id)` action — `SoloNode` dims itself when a different instance is soloed
- Cleared on node removal and patch load, same shape as the existing `playingNodes` cleanup

## Test plan
- [x] `npx tsc --noEmit` — no new errors beyond the pre-existing MUI typing debt
- [x] `npm run build` — passes clean
- [ ] Manual smoke test: add two Solo nodes, verify soloing one dims/mutes the other and toggling off restores both