### PR TITLE
Implement CrossFade + Panner: Tier 3 batch 2

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -121,6 +121,21 @@ const multibandSplitAdapter: PortAdapter = {
 	},
 };
 
+const crossFadeAdapter: PortAdapter = {
+	// CrossFade: no single `.input` — in-0/in-1 wire directly to toneNode.a/.b.
+	getInput: (entry, targetHandle) =>
+		entry.kind === 'crossFade' ? { node: targetHandle === 'in-1' ? entry.toneNode.b : entry.toneNode.a, channel: 0 } : null,
+	getOutput: (entry) => entry.kind === 'crossFade' ? { node: entry.toneNode, channel: 0 } : null,
+};
+
+const pannerAdapter: PortAdapter = {
+	// Panner: plain StereoPannerNode input; out-0/out-1 select the internal
+	// Split(2)'s two channels, since Panner has no native separate L/R taps.
+	getInput: (entry) => entry.kind === 'panner' ? { node: entry.toneNode, channel: 0 } : null,
+	getOutput: (entry, sourceHandle) =>
+		entry.kind === 'panner' ? { node: entry.split, channel: sourceHandle === 'out-1' ? 1 : 0 } : null,
+};
+
 const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	masterOutput: masterOutputAdapter,
 	player:       splitOutputAdapter,
@@ -130,6 +145,8 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	split:        splitNodeAdapter,
 	merge:        mergeNodeAdapter,
 	multibandSplit: multibandSplitAdapter,
+	crossFade:    crossFadeAdapter,
+	panner:       pannerAdapter,
 	oscillator:       genericAdapter,
 	gain:             genericAdapter,
 	noise:            genericAdapter,

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -59,6 +59,8 @@ import { multibandSplitHandler }   from './nodes/multibandSplit';
 import { analyserHandler }         from './nodes/analyser';
 import { followerHandler }         from './nodes/follower';
 import { soloHandler }             from './nodes/solo';
+import { crossFadeHandler }        from './nodes/crossFade';
+import { pannerHandler }           from './nodes/panner';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -146,3 +148,5 @@ nodeRegistry.register('multibandSplit',   multibandSplitHandler);
 nodeRegistry.register('analyser',         analyserHandler);
 nodeRegistry.register('follower',         followerHandler);
 nodeRegistry.register('solo',             soloHandler);
+nodeRegistry.register('crossFade',        crossFadeHandler);
+nodeRegistry.register('panner',           pannerHandler);

--- a/src/audio/nodes/crossFade.ts
+++ b/src/audio/nodes/crossFade.ts
@@ -1,0 +1,26 @@
+import { CrossFade } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { CrossFadeNodeData } from '../../store/dawTypes';
+
+export const crossFadeHandler: NodeTypeHandler<CrossFadeNodeData> = {
+	defaultData: { label: 'CrossFade', fade: 0.5 },
+
+	create(id, data) {
+		const toneNode = new CrossFade(data.fade);
+		_audioNodes.set(id, { kind: 'crossFade', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'crossFade') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'crossFade') return;
+		if (update.fade !== undefined) e.toneNode.fade.value = update.fade;
+	},
+};

--- a/src/audio/nodes/panner.ts
+++ b/src/audio/nodes/panner.ts
@@ -1,0 +1,33 @@
+import { Panner, Split } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { PannerNodeData } from '../../store/dawTypes';
+
+// Panner wraps a single stereo StereoPannerNode with no native separate L/R
+// taps — out-0/out-1 are satisfied by an internal Split(2), same shape as
+// player.ts's/grainPlayer.ts's split field.
+
+export const pannerHandler: NodeTypeHandler<PannerNodeData> = {
+	defaultData: { label: 'Panner', pan: 0 },
+
+	create(id, data) {
+		const toneNode = new Panner(data.pan);
+		const split    = new Split(2);
+		toneNode.connect(split);
+		_audioNodes.set(id, { kind: 'panner', toneNode, split });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner') return;
+		e.toneNode.dispose();
+		e.split.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner') return;
+		if (update.pan !== undefined) e.toneNode.pan.value = update.pan;
+	},
+};

--- a/src/audio/nodes/stub.ts
+++ b/src/audio/nodes/stub.ts
@@ -2,7 +2,7 @@ import type { NodeTypeHandler } from './nodeHandler';
 import type { StubNodeData } from '../../store/dawTypes';
 
 export const stubHandler: NodeTypeHandler<StubNodeData> = {
-	defaultData: { label: 'Stub', kind: 'panner' },
+	defaultData: { label: 'Stub', kind: 'channel' },
 	create()        { /* not yet implemented */ },
 	dispose()       { /* not yet implemented */ },
 	setAudioParam() { /* not yet implemented */ },

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -98,6 +98,8 @@ import { MonoNode }               from './nodes/processing/MonoNode';
 import { VolumeNode }             from './nodes/processing/VolumeNode';
 import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
 import { SoloNode }               from './nodes/processing/SoloNode';
+import { CrossFadeNode }          from './nodes/processing/CrossFadeNode';
+import { PannerNode }             from './nodes/processing/PannerNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
@@ -168,6 +170,8 @@ const nodeTypes = {
 	volume:           VolumeNode,
 	multibandSplit:   MultibandSplitNode,
 	solo:             SoloNode,
+	crossFade:        CrossFadeNode,
+	panner:           PannerNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,

--- a/src/daw/nodes/processing/CrossFadeNode.tsx
+++ b/src/daw/nodes/processing/CrossFadeNode.tsx
@@ -1,0 +1,38 @@
+import { memo, Fragment } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle, inputLabel, computeHandleTops } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { CrossFadeFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const LABELS = ['a', 'b'];
+
+export const CrossFadeNode = memo(function CrossFadeNode({ id, data, selected }: NodeProps<CrossFadeFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const tops = computeHandleTops(2, 'normal');
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='CrossFade' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='fade' value={data.fade} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { fade: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+			</Box>
+
+			{tops.map((top, i) => (
+				<Fragment key={i}>
+					<Handle type='target' position={Position.Left} id={`in-${i}`} style={{ ...inputHandleStyle(color), top }} />
+					{inputLabel(LABELS[i], top, color)}
+				</Fragment>
+			))}
+
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/PannerNode.tsx
+++ b/src/daw/nodes/processing/PannerNode.tsx
@@ -1,0 +1,35 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader, NODE_HEADER_HEIGHT } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, bottomOutputHandleStyle, outputLabel } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { PannerFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const INPUT_TOP = `calc(${NODE_HEADER_HEIGHT}px + 20px)`;
+
+export const PannerNode = memo(function PannerNode({ id, data, selected }: NodeProps<PannerFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', pb: 2.5, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Panner' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='pan' value={data.pan} min={-1} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { pan: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left} id='in-0' style={{ ...inputHandleStyle(color), top: INPUT_TOP }} />
+
+			<Handle type='source' position={Position.Bottom} id='out-0' style={{ ...bottomOutputHandleStyle(color), left: '33%' }} />
+			{outputLabel('L', color, '33%')}
+			<Handle type='source' position={Position.Bottom} id='out-1' style={{ ...bottomOutputHandleStyle(color), left: '67%' }} />
+			{outputLabel('R', color, '67%')}
+		</Box>
+	);
+});

--- a/src/daw/nodes/shared/StubNode.tsx
+++ b/src/daw/nodes/shared/StubNode.tsx
@@ -12,8 +12,6 @@ import type { StubFlowNode, StubKind } from '../../../store/dawTypes';
 // Only entries that differ from the default mono in → mono out topology.
 const STUB_TOPOLOGY: Partial<Record<StubKind, { inputs: string[]; outputs: string[] }>> = {
 	noiseGenerator: { inputs: [],               outputs: ['out-0'] },
-	panner:         { inputs: ['in-0'],         outputs: ['out-0', 'out-1'] },
-	crossFade:      { inputs: ['in-0', 'in-1'], outputs: ['out-0'] },
 	// Source-like stubs (instruments, oscillators) have no audio input
 	synth:          { inputs: [], outputs: ['out-0'] },
 	monoSynth:      { inputs: [], outputs: ['out-0'] },

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -486,6 +486,8 @@ const REAL_ACTIONS = new Set<string>([
 	'analyser',
 	'follower',
 	'solo',
+	'crossFade',
+	'panner',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -111,7 +111,6 @@ const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	midSideCompressor:   'MidSideCompressor',
 	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
-	crossFade:           'CrossFade',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
 	waveShaper:          'WaveShaper',

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -36,7 +36,7 @@ export type GainNodeData = {
 
 export type StubKind =
 	// — existing processing stubs (not yet implemented) —
-	| 'noiseGenerator' | 'panner'
+	| 'noiseGenerator'
 	// — Source / Instrument —
 	| 'omniOscillator'
 	| 'players' | 'userMedia'
@@ -45,7 +45,7 @@ export type StubKind =
 	// — Dynamics —
 	| 'midSideCompressor' | 'multibandCompressor'
 	// — Processing —
-	| 'channel' | 'panner3d' | 'crossFade'
+	| 'channel' | 'panner3d'
 	| 'convolver'
 	// — Analysis —
 	| 'recorder'
@@ -426,6 +426,22 @@ export type MultibandSplitFlowNode = Node<MultibandSplitNodeData, 'multibandSpli
 export type SoloNodeData = { label: string };
 export type SoloFlowNode = Node<SoloNodeData, 'solo'>;
 
+// Panner wraps a single stereo StereoPannerNode — it has no native separate
+// L/R outputs. out-0/out-1 are a reactoscope design choice, satisfied by an
+// internal Split(2) the handler wires the panner's output into.
+export type PannerNodeData = {
+	label: string;
+	pan:   number;   // -1–1, default 0
+};
+export type PannerFlowNode = Node<PannerNodeData, 'panner'>;
+
+// CrossFade has no single `.input` — in-0/in-1 wire directly to toneNode.a/.b.
+export type CrossFadeNodeData = {
+	label: string;
+	fade:  number;   // 0–1, default 0.5
+};
+export type CrossFadeFlowNode = Node<CrossFadeNodeData, 'crossFade'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
@@ -562,6 +578,8 @@ export type AppNode =
 	| VolumeFlowNode
 	| MultibandSplitFlowNode
 	| SoloFlowNode
+	| PannerFlowNode
+	| CrossFadeFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
@@ -718,6 +736,8 @@ export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
 export type VolumeAudioEntry      = { kind: 'volume';      toneNode: Volume };
 export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: MultibandSplit };
 export type SoloAudioEntry        = { kind: 'solo';        toneNode: Solo };
+export type PannerAudioEntry      = { kind: 'panner';      toneNode: Panner; split: Split };
+export type CrossFadeAudioEntry   = { kind: 'crossFade';   toneNode: CrossFade };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
@@ -782,6 +802,8 @@ export type AudioNodeEntry =
 	| VolumeAudioEntry
 	| MultibandSplitAudioEntry
 	| SoloAudioEntry
+	| PannerAudioEntry
+	| CrossFadeAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry


### PR DESCRIPTION
## Summary
- Second Tier 3 implementation batch: CrossFade and Panner, per the batching order agreed in #25
- Both just extend the connection-adapter pattern Split/Merge/MultibandSplit already established in Tier 1/2 — no new UI or wiring patterns
- **CrossFade**: `input` is `undefined` on the Tone.js class — `in-0`/`in-1` wire directly to `toneNode.a`/`.b`
- **Panner**: wraps a single stereo `StereoPannerNode` with no native L/R taps — `out-0`/`out-1` satisfied by an internal `Split(2)`, same shape as `player.ts`'s/`grainPlayer.ts`'s `split` field

**Stacked on #26** (Solo, not yet merged) — this branch continues from it rather than re-basing onto `next`, since the two batches only share adjacent lines in the same files (`dawTypes.ts`, `audioCore.ts`, etc.), not any actual logic dependency. Merge #26 first.

## Test plan
- [x] `npx tsc --noEmit` — no new errors beyond the pre-existing MUI typing debt
- [x] `npm run build` — passes clean
- [ ] Manual smoke test: wire two oscillators into CrossFade's a/b inputs and sweep fade; connect a Panner's L/R outputs to Master Output and sweep pan