### PR TITLE
Implement MidSideCompressor: Tier 3 batch 3

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -179,6 +179,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	limiter:          genericAdapter,
 	gate:             genericAdapter,
 	compressor:       genericAdapter,
+	midSideCompressor: genericAdapter,
 	biquadFilter:     genericAdapter,
 	filter:           genericAdapter,
 	eq3:              genericAdapter,

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -61,6 +61,7 @@ import { followerHandler }         from './nodes/follower';
 import { soloHandler }             from './nodes/solo';
 import { crossFadeHandler }        from './nodes/crossFade';
 import { pannerHandler }           from './nodes/panner';
+import { midSideCompressorHandler } from './nodes/midSideCompressor';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -150,3 +151,4 @@ nodeRegistry.register('follower',         followerHandler);
 nodeRegistry.register('solo',             soloHandler);
 nodeRegistry.register('crossFade',        crossFadeHandler);
 nodeRegistry.register('panner',           pannerHandler);
+nodeRegistry.register('midSideCompressor', midSideCompressorHandler);

--- a/src/audio/nodes/compressor.ts
+++ b/src/audio/nodes/compressor.ts
@@ -1,7 +1,16 @@
 import { Compressor } from 'tone';
 import { _audioNodes } from '../audioCore';
 import type { NodeTypeHandler } from './nodeHandler';
-import type { CompressorNodeData } from '../../store/dawTypes';
+import type { CompressorNodeData, CompressorBandData } from '../../store/dawTypes';
+
+/** Applies a partial band update to a real Compressor instance — shared with MidSideCompressor/MultibandCompressor, whose `mid`/`side`/`low`/`high` bands are each a full Compressor instance too. */
+export function applyCompressorBand(node: Compressor, update: Partial<CompressorBandData>): void {
+	if (update.threshold !== undefined) node.threshold.value = update.threshold;
+	if (update.ratio     !== undefined) node.ratio.value     = update.ratio;
+	if (update.attack    !== undefined) node.attack.value    = update.attack;
+	if (update.release   !== undefined) node.release.value   = update.release;
+	if (update.knee      !== undefined) node.knee.value      = update.knee;
+}
 
 export const compressorHandler: NodeTypeHandler<CompressorNodeData> = {
 	defaultData: { label: 'Compressor', threshold: -24, ratio: 12, attack: 0.003, release: 0.25, knee: 30 },
@@ -27,10 +36,6 @@ export const compressorHandler: NodeTypeHandler<CompressorNodeData> = {
 	setAudioParam(id, update) {
 		const e = _audioNodes.get(id);
 		if (e?.kind !== 'compressor') return;
-		if (update.threshold !== undefined) e.toneNode.threshold.value = update.threshold;
-		if (update.ratio     !== undefined) e.toneNode.ratio.value     = update.ratio;
-		if (update.attack    !== undefined) e.toneNode.attack.value    = update.attack;
-		if (update.release   !== undefined) e.toneNode.release.value   = update.release;
-		if (update.knee      !== undefined) e.toneNode.knee.value      = update.knee;
+		applyCompressorBand(e.toneNode, update);
 	},
 };

--- a/src/audio/nodes/midSideCompressor.ts
+++ b/src/audio/nodes/midSideCompressor.ts
@@ -1,0 +1,31 @@
+import { MidSideCompressor } from 'tone';
+import { _audioNodes } from '../audioCore';
+import { applyCompressorBand } from './compressor';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { MidSideCompressorNodeData } from '../../store/dawTypes';
+
+const DEFAULT_MID  = { threshold: -24, ratio: 3, attack: 0.02, release: 0.03, knee: 16 };
+const DEFAULT_SIDE = { threshold: -30, ratio: 6, attack: 0.03, release: 0.25, knee: 10 };
+
+export const midSideCompressorHandler: NodeTypeHandler<MidSideCompressorNodeData> = {
+	defaultData: { label: 'MidSideCompressor', mid: DEFAULT_MID, side: DEFAULT_SIDE },
+
+	create(id, data) {
+		const toneNode = new MidSideCompressor({ mid: data.mid, side: data.side });
+		_audioNodes.set(id, { kind: 'midSideCompressor', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'midSideCompressor') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'midSideCompressor') return;
+		if (update.mid)  applyCompressorBand(e.toneNode.mid,  update.mid);
+		if (update.side) applyCompressorBand(e.toneNode.side, update.side);
+	},
+};

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -88,6 +88,7 @@ import { AutoWahNode }            from './nodes/effects/AutoWahNode';
 import { LimiterNode }            from './nodes/dynamics/LimiterNode';
 import { GateNode }               from './nodes/dynamics/GateNode';
 import { CompressorNode }         from './nodes/dynamics/CompressorNode';
+import { MidSideCompressorNode }  from './nodes/dynamics/MidSideCompressorNode';
 import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
 import { FilterNode }             from './nodes/processing/FilterNode';
 import { EQ3Node }                from './nodes/processing/EQ3Node';
@@ -160,6 +161,7 @@ const nodeTypes = {
 	limiter:          LimiterNode,
 	gate:             GateNode,
 	compressor:       CompressorNode,
+	midSideCompressor: MidSideCompressorNode,
 	biquadFilter:     BiquadFilterNode,
 	filter:           FilterNode,
 	eq3:              EQ3Node,

--- a/src/daw/nodes/dynamics/CompressorNode.tsx
+++ b/src/daw/nodes/dynamics/CompressorNode.tsx
@@ -7,7 +7,7 @@ import { NODE_COLORS } from '../shared/nodeColors';
 import { GRID_UNIT } from '../shared/gridSystem';
 import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
-import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import { CompressorControls } from '../shared/CompressorControls';
 import type { CompressorFlowNode } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.dynamics;
@@ -19,12 +19,8 @@ export const CompressorNode = memo(function CompressorNode({ id, data, selected 
 		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
 			<NodeHeader id={id} label='Compressor' selected={selected} accentColor={color} filledHeader />
 
-			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider label='threshold' value={data.threshold} min={-100} max={0}  step={1}    color={color} onChange={v => setNodeParam(id, { threshold: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='ratio'     value={data.ratio}     min={1}    max={20} step={0.5}  color={color} onChange={v => setNodeParam(id, { ratio: v })}     format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='attack'    value={data.attack}    min={0}    max={1}  step={0.001} color={color} onChange={v => setNodeParam(id, { attack: v })}   format={v => v.toFixed(3)} unit='s'  allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='release'   value={data.release}   min={0}    max={1}  step={0.01}  color={color} onChange={v => setNodeParam(id, { release: v })}  format={v => v.toFixed(2)} unit='s'  allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='knee'      value={data.knee}      min={0}    max={40} step={1}     color={color} onChange={v => setNodeParam(id, { knee: v })}     format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75 }} className='nodrag nowheel'>
+				<CompressorControls value={data} onChange={update => setNodeParam(id, update)} color={color} />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/dynamics/MidSideCompressorNode.tsx
+++ b/src/daw/nodes/dynamics/MidSideCompressorNode.tsx
@@ -1,0 +1,44 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { CompressorControls } from '../shared/CompressorControls';
+import type { MidSideCompressorFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.dynamics;
+
+export const MidSideCompressorNode = memo(function MidSideCompressorNode({ id, data, selected }: NodeProps<MidSideCompressorFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='MidSideCompressor' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 1, textAlign: 'center' }}>
+				<Typography variant='caption' color='text.disabled' sx={{ fontSize: 9 }}>
+					requires a stereo input signal
+				</Typography>
+			</Box>
+
+			<Box sx={{ px: 1.75, pt: 1, pb: 0.75, display: 'flex', gap: 2 }} className='nodrag nowheel'>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>mid</Typography>
+					<CompressorControls value={data.mid} onChange={update => setNodeParam(id, { mid: { ...data.mid, ...update } })} color={color} />
+				</Box>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>side</Typography>
+					<CompressorControls value={data.side} onChange={update => setNodeParam(id, { side: { ...data.side, ...update } })} color={color} />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/shared/CompressorControls.tsx
+++ b/src/daw/nodes/shared/CompressorControls.tsx
@@ -1,0 +1,45 @@
+import Box from '@mui/material/Box';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { CompressorBandData } from '../../../store/dawTypes';
+
+const ALL_PARAMS: (keyof CompressorBandData)[] = ['threshold', 'ratio', 'attack', 'release', 'knee'];
+
+type Props = {
+	value:    CompressorBandData;
+	onChange: (update: Partial<CompressorBandData>) => void;
+	color:    string;
+	/** Which sliders to show — defaults to all 5. MultibandCompressor's v1 scope shows threshold+ratio only (docs/node-roadmap.md). */
+	params?:  (keyof CompressorBandData)[];
+};
+
+/**
+ * The threshold/ratio/attack/release/knee slider row every real Compressor
+ * band needs — standalone Compressor, and each band of MidSideCompressor/
+ * MultibandCompressor (docs/adr/0004-nested-param-panel-layout.md).
+ */
+export function CompressorControls({ value, onChange, color, params = ALL_PARAMS }: Props) {
+	return (
+		<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+			{params.includes('threshold') && (
+				<HwArcSlider label='threshold' value={value.threshold} min={-100} max={0} step={1} color={color}
+					onChange={v => onChange({ threshold: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('ratio') && (
+				<HwArcSlider label='ratio' value={value.ratio} min={1} max={20} step={0.5} color={color}
+					onChange={v => onChange({ ratio: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('attack') && (
+				<HwArcSlider label='attack' value={value.attack} min={0} max={1} step={0.001} color={color}
+					onChange={v => onChange({ attack: v })} format={v => v.toFixed(3)} unit='s' allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('release') && (
+				<HwArcSlider label='release' value={value.release} min={0} max={1} step={0.01} color={color}
+					onChange={v => onChange({ release: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('knee') && (
+				<HwArcSlider label='knee' value={value.knee} min={0} max={40} step={1} color={color}
+					onChange={v => onChange({ knee: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			)}
+		</Box>
+	);
+}

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -488,6 +488,7 @@ const REAL_ACTIONS = new Set<string>([
 	'solo',
 	'crossFade',
 	'panner',
+	'midSideCompressor',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -108,7 +108,6 @@ function edgeColorForSource(sourceId: string, nodes: AppNode[]): string {
 // Everything else falls back to capitalising the action string.
 const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
-	midSideCompressor:   'MidSideCompressor',
 	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
 	amplitudeEnvelope:   'AmplitudeEnvelope',

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -43,7 +43,7 @@ export type StubKind =
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
 	// — Dynamics —
-	| 'midSideCompressor' | 'multibandCompressor'
+	| 'multibandCompressor'
 	// — Processing —
 	| 'channel' | 'panner3d'
 	| 'convolver'
@@ -341,15 +341,28 @@ export type GateNodeData = {
 };
 export type GateFlowNode = Node<GateNodeData, 'gate'>;
 
-export type CompressorNodeData = {
-	label:     string;
+// Shared by every node with a real Compressor band — standalone Compressor,
+// and MidSideCompressor's/MultibandCompressor's mid/side/low/high children
+// (see CompressorControls, docs/adr/0004-nested-param-panel-layout.md).
+export type CompressorBandData = {
 	threshold: number;   // dB, -100–0, default -24
 	ratio:     number;   // 1–20, default 12
 	attack:    number;   // seconds, 0–1, default 0.003
 	release:   number;   // seconds, 0–1, default 0.25
 	knee:      number;   // dB, 0–40, default 30
 };
+
+export type CompressorNodeData = { label: string } & CompressorBandData;
 export type CompressorFlowNode = Node<CompressorNodeData, 'compressor'>;
+
+// Requires a genuinely stereo input — mid/side encoding is meaningless on
+// mono, flagged in the node's UI (docs/node-roadmap.md).
+export type MidSideCompressorNodeData = {
+	label: string;
+	mid:   CompressorBandData;
+	side:  CompressorBandData;
+};
+export type MidSideCompressorFlowNode = Node<MidSideCompressorNodeData, 'midSideCompressor'>;
 
 // ─── Processing node data types ───────────────────────────────────────────────
 
@@ -568,6 +581,7 @@ export type AppNode =
 	| LimiterFlowNode
 	| GateFlowNode
 	| CompressorFlowNode
+	| MidSideCompressorFlowNode
 	| BiquadFilterFlowNode
 	| FilterFlowNode
 	| EQ3FlowNode
@@ -726,6 +740,7 @@ export type AutoWahAudioEntry         = { kind: 'autoWah';          toneNode: Au
 export type LimiterAudioEntry     = { kind: 'limiter';     toneNode: Limiter };
 export type GateAudioEntry        = { kind: 'gate';        toneNode: Gate };
 export type CompressorAudioEntry  = { kind: 'compressor';  toneNode: Compressor };
+export type MidSideCompressorAudioEntry = { kind: 'midSideCompressor'; toneNode: MidSideCompressor };
 export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFilter };
 export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
 export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
@@ -792,6 +807,7 @@ export type AudioNodeEntry =
 	| LimiterAudioEntry
 	| GateAudioEntry
 	| CompressorAudioEntry
+	| MidSideCompressorAudioEntry
 	| BiquadFilterAudioEntry
 	| FilterAudioEntry
 	| EQ3AudioEntry


### PR DESCRIPTION
## Summary
- Third Tier 3 implementation batch, per the batching order agreed in #25
- Establishes the nested/grouped param panel pattern (`docs/adr/0004-nested-param-panel-layout.md`) — reactoscope's first node UI with more than one param group in a single body
- Extracted `CompressorControls` (`src/daw/nodes/shared/`) from `CompressorNode.tsx`'s slider row; `MidSideCompressorNode` renders two side-by-side, always-visible sub-panels (mid/side) using it
- `applyCompressorBand()` added to `compressor.ts` — shared logic MultibandCompressor will reuse for its low/mid/high bands next
- Flagged the "requires stereo input" constraint directly in the node's UI, not just a comment

**Stacked on #27** (CrossFade + Panner, not yet merged). Merge order: #26 → #27 → this.

## Test plan
- [x] `npx tsc --noEmit` — no new errors beyond the pre-existing MUI typing debt
- [x] `npm run build` — passes clean
- [ ] Manual smoke test: add a MidSideCompressor, verify both mid/side sliders move independently and the audio compresses correctly on a stereo source