### PR TITLE
Implement MultibandCompressor: Tier 3 batch 4

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -180,6 +180,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	gate:             genericAdapter,
 	compressor:       genericAdapter,
 	midSideCompressor: genericAdapter,
+	multibandCompressor: genericAdapter,
 	biquadFilter:     genericAdapter,
 	filter:           genericAdapter,
 	eq3:              genericAdapter,

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -62,6 +62,7 @@ import { soloHandler }             from './nodes/solo';
 import { crossFadeHandler }        from './nodes/crossFade';
 import { pannerHandler }           from './nodes/panner';
 import { midSideCompressorHandler } from './nodes/midSideCompressor';
+import { multibandCompressorHandler } from './nodes/multibandCompressor';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -152,3 +153,4 @@ nodeRegistry.register('solo',             soloHandler);
 nodeRegistry.register('crossFade',        crossFadeHandler);
 nodeRegistry.register('panner',           pannerHandler);
 nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
+nodeRegistry.register('multibandCompressor', multibandCompressorHandler);

--- a/src/audio/nodes/multibandCompressor.ts
+++ b/src/audio/nodes/multibandCompressor.ts
@@ -1,0 +1,46 @@
+import { MultibandCompressor } from 'tone';
+import { _audioNodes } from '../audioCore';
+import { applyCompressorBand } from './compressor';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { MultibandCompressorNodeData } from '../../store/dawTypes';
+
+const DEFAULT_BAND = { threshold: -24, ratio: 12, attack: 0.003, release: 0.25, knee: 30 };
+
+export const multibandCompressorHandler: NodeTypeHandler<MultibandCompressorNodeData> = {
+	defaultData: {
+		label:         'MultibandCompressor',
+		lowFrequency:  250,
+		highFrequency: 2000,
+		low:           DEFAULT_BAND,
+		mid:           DEFAULT_BAND,
+		high:          DEFAULT_BAND,
+	},
+
+	create(id, data) {
+		const toneNode = new MultibandCompressor({
+			lowFrequency:  data.lowFrequency,
+			highFrequency: data.highFrequency,
+			low:           data.low,
+			mid:           data.mid,
+			high:          data.high,
+		});
+		_audioNodes.set(id, { kind: 'multibandCompressor', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandCompressor') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandCompressor') return;
+		if (update.lowFrequency  !== undefined) e.toneNode.lowFrequency.value  = update.lowFrequency;
+		if (update.highFrequency !== undefined) e.toneNode.highFrequency.value = update.highFrequency;
+		if (update.low)  applyCompressorBand(e.toneNode.low,  update.low);
+		if (update.mid)  applyCompressorBand(e.toneNode.mid,  update.mid);
+		if (update.high) applyCompressorBand(e.toneNode.high, update.high);
+	},
+};

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -89,6 +89,7 @@ import { LimiterNode }            from './nodes/dynamics/LimiterNode';
 import { GateNode }               from './nodes/dynamics/GateNode';
 import { CompressorNode }         from './nodes/dynamics/CompressorNode';
 import { MidSideCompressorNode }  from './nodes/dynamics/MidSideCompressorNode';
+import { MultibandCompressorNode } from './nodes/dynamics/MultibandCompressorNode';
 import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
 import { FilterNode }             from './nodes/processing/FilterNode';
 import { EQ3Node }                from './nodes/processing/EQ3Node';
@@ -162,6 +163,7 @@ const nodeTypes = {
 	gate:             GateNode,
 	compressor:       CompressorNode,
 	midSideCompressor: MidSideCompressorNode,
+	multibandCompressor: MultibandCompressorNode,
 	biquadFilter:     BiquadFilterNode,
 	filter:           FilterNode,
 	eq3:              EQ3Node,

--- a/src/daw/nodes/dynamics/MultibandCompressorNode.tsx
+++ b/src/daw/nodes/dynamics/MultibandCompressorNode.tsx
@@ -1,0 +1,54 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import { CompressorControls } from '../shared/CompressorControls';
+import type { MultibandCompressorFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.dynamics;
+
+// v1 UI shows threshold+ratio only per band — attack/release/knee stay at
+// their defaults (docs/node-roadmap.md: 17 live controls is too heavy).
+const BAND_PARAMS = ['threshold', 'ratio'] as const;
+
+export const MultibandCompressorNode = memo(function MultibandCompressorNode({ id, data, selected }: NodeProps<MultibandCompressorFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 7 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='MultibandCompressor' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 1, pb: 0.5, display: 'flex', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='low freq' value={data.lowFrequency}  min={20}  max={2000}  step={10} color={color}
+					onChange={v => setNodeParam(id, { lowFrequency: v })}  format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='hi freq'  value={data.highFrequency} min={200} max={20000} step={10} color={color}
+					onChange={v => setNodeParam(id, { highFrequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Box sx={{ px: 1.75, pb: 0.75, display: 'flex', gap: 1.5 }} className='nodrag nowheel'>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>low</Typography>
+					<CompressorControls value={data.low} onChange={update => setNodeParam(id, { low: { ...data.low, ...update } })} color={color} params={[...BAND_PARAMS]} />
+				</Box>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>mid</Typography>
+					<CompressorControls value={data.mid} onChange={update => setNodeParam(id, { mid: { ...data.mid, ...update } })} color={color} params={[...BAND_PARAMS]} />
+				</Box>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>high</Typography>
+					<CompressorControls value={data.high} onChange={update => setNodeParam(id, { high: { ...data.high, ...update } })} color={color} params={[...BAND_PARAMS]} />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -489,6 +489,7 @@ const REAL_ACTIONS = new Set<string>([
 	'crossFade',
 	'panner',
 	'midSideCompressor',
+	'multibandCompressor',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -108,7 +108,6 @@ function edgeColorForSource(sourceId: string, nodes: AppNode[]): string {
 // Everything else falls back to capitalising the action string.
 const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
-	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -42,8 +42,6 @@ export type StubKind =
 	| 'players' | 'userMedia'
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
-	// — Dynamics —
-	| 'multibandCompressor'
 	// — Processing —
 	| 'channel' | 'panner3d'
 	| 'convolver'
@@ -364,6 +362,19 @@ export type MidSideCompressorNodeData = {
 };
 export type MidSideCompressorFlowNode = Node<MidSideCompressorNodeData, 'midSideCompressor'>;
 
+// v1 UI exposes only threshold+ratio per band via CompressorControls' `params`
+// prop (docs/node-roadmap.md: 17 live controls is too heavy) — attack/release/
+// knee still live on each band's data, just defaulted and not user-editable yet.
+export type MultibandCompressorNodeData = {
+	label:         string;
+	lowFrequency:  number;   // Hz, 20–2000, default 250
+	highFrequency: number;   // Hz, 200–20000, default 2000
+	low:           CompressorBandData;
+	mid:           CompressorBandData;
+	high:          CompressorBandData;
+};
+export type MultibandCompressorFlowNode = Node<MultibandCompressorNodeData, 'multibandCompressor'>;
+
 // ─── Processing node data types ───────────────────────────────────────────────
 
 export type BiquadFilterType = 'lowpass' | 'highpass' | 'bandpass' | 'lowshelf' | 'highshelf' | 'notch' | 'allpass' | 'peaking';
@@ -582,6 +593,7 @@ export type AppNode =
 	| GateFlowNode
 	| CompressorFlowNode
 	| MidSideCompressorFlowNode
+	| MultibandCompressorFlowNode
 	| BiquadFilterFlowNode
 	| FilterFlowNode
 	| EQ3FlowNode
@@ -741,6 +753,7 @@ export type LimiterAudioEntry     = { kind: 'limiter';     toneNode: Limiter };
 export type GateAudioEntry        = { kind: 'gate';        toneNode: Gate };
 export type CompressorAudioEntry  = { kind: 'compressor';  toneNode: Compressor };
 export type MidSideCompressorAudioEntry = { kind: 'midSideCompressor'; toneNode: MidSideCompressor };
+export type MultibandCompressorAudioEntry = { kind: 'multibandCompressor'; toneNode: MultibandCompressor };
 export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFilter };
 export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
 export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
@@ -808,6 +821,7 @@ export type AudioNodeEntry =
 	| GateAudioEntry
 	| CompressorAudioEntry
 	| MidSideCompressorAudioEntry
+	| MultibandCompressorAudioEntry
 	| BiquadFilterAudioEntry
 	| FilterAudioEntry
 	| EQ3AudioEntry


### PR DESCRIPTION
## Summary
- Implements `MultibandCompressor` (Tier 3), reusing the nested-panel layout established for `MidSideCompressor` (ADR-0004): three side-by-side low/mid/high sub-panels, each a `CompressorControls` instance sharing `applyCompressorBand()`.
- Per the roadmap's scope call (17 live controls across 3 bands is too heavy for v1), each band panel exposes only **threshold + ratio** via `CompressorControls`' existing `params` prop — attack/release/knee still live on the node data and drive the real Tone.js `Compressor` instances correctly, just not user-editable yet.
- `lowFrequency`/`highFrequency` crossover points get their own arc sliders, matching `MultibandSplit`'s existing UI/ranges.
- `.input`/`.output` on `MultibandCompressor` are plain, so `genericAdapter` handles routing — no custom `PortAdapter` needed.

## Merge order
Stacked branch: this PR targets `worktree-tier3-midsidecompressor`, which targets `worktree-tier3-crossfade-panner`, which targets `next`. Merge order: #26 (Solo) → #27 (CrossFade+Panner) → #28 (MidSideCompressor) → this PR.

## Test plan
- [x] `npx tsc --noEmit` — 17 pre-existing errors (unrelated MUI typing debt), 0 new
- [x] `npm run build` — clean
- [ ] Manual: add a MultibandCompressor node, verify low/mid/high threshold+ratio sliders affect audio and the crossover frequency sliders move the split points

🤖 Generated with [Claude Code](https://claude.com/claude-code)