### PR TITLE
Lay out oscillator waveform buttons as a 2x2 grid

### DIFF
--- a/src/daw/nodes/source/AMOscillatorNode.tsx
+++ b/src/daw/nodes/source/AMOscillatorNode.tsx
@@ -39,18 +39,29 @@ function WaveRow({
 			>
 				{rowLabel}
 			</Typography>
-			<Box sx={{ display: 'flex', gap: '1px' }}>
+			<Box
+				sx={{
+					display: 'grid',
+					gridTemplateColumns: 'repeat(2, 1fr)',
+					gap: '1px',
+				}}
+			>
 				{OSC_TYPES.map((t, i) => {
 					const active = value === t;
 					const lit = hwLit(color);
 					const radius =
-						i === 0 ? '3px 0 0 3px' : i === 3 ? '0 3px 3px 0' : '0';
+						i === 0
+							? '3px 0 0 0'
+							: i === 1
+								? '0 3px 0 0'
+								: i === 2
+									? '0 0 0 3px'
+									: '0 0 3px 0';
 					return (
 						<Box
 							key={t}
 							onClick={() => onChange(t)}
 							sx={{
-								flex: 1,
 								display: 'flex',
 								alignItems: 'center',
 								justifyContent: 'center',

--- a/src/daw/nodes/source/FMOscillatorNode.tsx
+++ b/src/daw/nodes/source/FMOscillatorNode.tsx
@@ -39,18 +39,29 @@ function WaveRow({
 			>
 				{rowLabel}
 			</Typography>
-			<Box sx={{ display: 'flex', gap: '1px' }}>
+			<Box
+				sx={{
+					display: 'grid',
+					gridTemplateColumns: 'repeat(2, 1fr)',
+					gap: '1px',
+				}}
+			>
 				{OSC_TYPES.map((t, i) => {
 					const active = value === t;
 					const lit = hwLit(color);
 					const radius =
-						i === 0 ? '3px 0 0 3px' : i === 3 ? '0 3px 3px 0' : '0';
+						i === 0
+							? '3px 0 0 0'
+							: i === 1
+								? '0 3px 0 0'
+								: i === 2
+									? '0 0 0 3px'
+									: '0 0 3px 0';
 					return (
 						<Box
 							key={t}
 							onClick={() => onChange(t)}
 							sx={{
-								flex: 1,
 								display: 'flex',
 								alignItems: 'center',
 								justifyContent: 'center',

--- a/src/daw/nodes/source/FatOscillatorNode.tsx
+++ b/src/daw/nodes/source/FatOscillatorNode.tsx
@@ -68,18 +68,29 @@ export const FatOscillatorNode = memo(function FatOscillatorNode({
 					className='nodrag'
 					sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}
 				>
-					<Box sx={{ display: 'flex', gap: '1px' }}>
+					<Box
+						sx={{
+							display: 'grid',
+							gridTemplateColumns: 'repeat(2, 1fr)',
+							gap: '1px',
+						}}
+					>
 						{OSC_TYPES.map((t: OscType, i) => {
 							const active = data.type === t;
 							const lit = hwLit(color);
 							const radius =
-								i === 0 ? '3px 0 0 3px' : i === 3 ? '0 3px 3px 0' : '0';
+								i === 0
+									? '3px 0 0 0'
+									: i === 1
+										? '0 3px 0 0'
+										: i === 2
+											? '0 0 0 3px'
+											: '0 0 3px 0';
 							return (
 								<Box
 									key={t}
 									onClick={() => setNodeParam(id, { type: t })}
 									sx={{
-										flex: 1,
 										display: 'flex',
 										alignItems: 'center',
 										justifyContent: 'center',

--- a/src/daw/nodes/source/LFONode.tsx
+++ b/src/daw/nodes/source/LFONode.tsx
@@ -68,18 +68,29 @@ export const LFONode = memo(function LFONode({
 					className='nodrag'
 					sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}
 				>
-					<Box sx={{ display: 'flex', gap: '1px' }}>
+					<Box
+						sx={{
+							display: 'grid',
+							gridTemplateColumns: 'repeat(2, 1fr)',
+							gap: '1px',
+						}}
+					>
 						{OSC_TYPES.map((t: OscType, i) => {
 							const active = data.type === t;
 							const lit = hwLit(color);
 							const radius =
-								i === 0 ? '3px 0 0 3px' : i === 3 ? '0 3px 3px 0' : '0';
+								i === 0
+									? '3px 0 0 0'
+									: i === 1
+										? '0 3px 0 0'
+										: i === 2
+											? '0 0 0 3px'
+											: '0 0 3px 0';
 							return (
 								<Box
 									key={t}
 									onClick={() => setNodeParam(id, { type: t })}
 									sx={{
-										flex: 1,
 										display: 'flex',
 										alignItems: 'center',
 										justifyContent: 'center',

--- a/src/daw/nodes/source/OscillatorNode.tsx
+++ b/src/daw/nodes/source/OscillatorNode.tsx
@@ -68,18 +68,29 @@ export const OscillatorNode = memo(function OscillatorNode({
 					className='nodrag'
 					sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}
 				>
-					<Box sx={{ display: 'flex', gap: '1px' }}>
+					<Box
+						sx={{
+							display: 'grid',
+							gridTemplateColumns: 'repeat(2, 1fr)',
+							gap: '1px',
+						}}
+					>
 						{OSC_TYPES.map((t, i) => {
 							const active = data.type === t;
 							const lit = hwLit(color);
 							const radius =
-								i === 0 ? '3px 0 0 3px' : i === 3 ? '0 3px 3px 0' : '0';
+								i === 0
+									? '3px 0 0 0'
+									: i === 1
+										? '0 3px 0 0'
+										: i === 2
+											? '0 0 0 3px'
+											: '0 0 3px 0';
 							return (
 								<Box
 									key={t}
 									onClick={() => setNodeParam(id, { type: t })}
 									sx={{
-										flex: 1,
 										display: 'flex',
 										alignItems: 'center',
 										justifyContent: 'center',


### PR DESCRIPTION
Replaces the single row of 4 waveform buttons with a 2x2 grid across Oscillator, AM/FM Oscillator, Fat Oscillator, and LFO nodes, adjusting corner radii to match the new layout.