### PR TITLE
Implement Panner3D: Tier 3 batch 5

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -147,6 +147,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	multibandSplit: multibandSplitAdapter,
 	crossFade:    crossFadeAdapter,
 	panner:       pannerAdapter,
+	panner3d:     genericAdapter,
 	oscillator:       genericAdapter,
 	gain:             genericAdapter,
 	noise:            genericAdapter,

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -63,6 +63,7 @@ import { crossFadeHandler }        from './nodes/crossFade';
 import { pannerHandler }           from './nodes/panner';
 import { midSideCompressorHandler } from './nodes/midSideCompressor';
 import { multibandCompressorHandler } from './nodes/multibandCompressor';
+import { panner3dHandler } from './nodes/panner3d';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -154,3 +155,4 @@ nodeRegistry.register('crossFade',        crossFadeHandler);
 nodeRegistry.register('panner',           pannerHandler);
 nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
 nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
+nodeRegistry.register('panner3d', panner3dHandler);

--- a/src/audio/nodes/panner3d.ts
+++ b/src/audio/nodes/panner3d.ts
@@ -1,0 +1,34 @@
+import { Panner3D } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { Panner3DNodeData } from '../../store/dawTypes';
+
+export const panner3dHandler: NodeTypeHandler<Panner3DNodeData> = {
+	defaultData: { label: 'Panner3D', positionX: 0, positionY: 0, positionZ: 0, panningModel: 'equalpower' },
+
+	create(id, data) {
+		const toneNode = new Panner3D({
+			positionX:    data.positionX,
+			positionY:    data.positionY,
+			positionZ:    data.positionZ,
+			panningModel: data.panningModel,
+		});
+		_audioNodes.set(id, { kind: 'panner3d', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner3d') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner3d') return;
+		if (update.positionX    !== undefined) e.toneNode.positionX.value = update.positionX;
+		if (update.positionY    !== undefined) e.toneNode.positionY.value = update.positionY;
+		if (update.positionZ    !== undefined) e.toneNode.positionZ.value = update.positionZ;
+		if (update.panningModel !== undefined) e.toneNode.panningModel    = update.panningModel;
+	},
+};

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -102,6 +102,7 @@ import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
 import { SoloNode }               from './nodes/processing/SoloNode';
 import { CrossFadeNode }          from './nodes/processing/CrossFadeNode';
 import { PannerNode }             from './nodes/processing/PannerNode';
+import { Panner3DNode }           from './nodes/processing/Panner3DNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
@@ -176,6 +177,7 @@ const nodeTypes = {
 	solo:             SoloNode,
 	crossFade:        CrossFadeNode,
 	panner:           PannerNode,
+	panner3d:         Panner3DNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,

--- a/src/daw/nodes/processing/Panner3DNode.tsx
+++ b/src/daw/nodes/processing/Panner3DNode.tsx
@@ -1,0 +1,49 @@
+import { memo, useMemo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx } from '../shared/hwStyles';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { Panner3DFlowNode, Panner3DPanningModel } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const PANNING_MODELS: Panner3DPanningModel[] = ['equalpower', 'HRTF'];
+
+export const Panner3DNode = memo(function Panner3DNode({ id, data, selected }: NodeProps<Panner3DFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const sx = useMemo(() => ({
+		select:     hwSelectSx(color, 'small'),
+		selectMenu: hwSelectMenuProps(color),
+		menuItem:   hwMenuItemSx(color),
+	}), []);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 3 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Panner3D' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Select value={data.panningModel} onChange={e => setNodeParam(id, { panningModel: e.target.value as Panner3DPanningModel })} fullWidth
+					sx={sx.select} MenuProps={sx.selectMenu}>
+					{PANNING_MODELS.map(m => (
+						<MenuItem key={m} value={m} sx={sx.menuItem}>{m}</MenuItem>
+					))}
+				</Select>
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='x' value={data.positionX} min={-10} max={10} step={0.1} color={color} onChange={v => setNodeParam(id, { positionX: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='y' value={data.positionY} min={-10} max={10} step={0.1} color={color} onChange={v => setNodeParam(id, { positionY: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='z' value={data.positionZ} min={-10} max={10} step={0.1} color={color} onChange={v => setNodeParam(id, { positionZ: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -488,6 +488,7 @@ const REAL_ACTIONS = new Set<string>([
 	'solo',
 	'crossFade',
 	'panner',
+	'panner3d',
 	'midSideCompressor',
 	'multibandCompressor',
 ]);

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -108,7 +108,6 @@ function edgeColorForSource(sourceId: string, nodes: AppNode[]): string {
 // Everything else falls back to capitalising the action string.
 const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
-	panner3d:            'Panner3D',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
 	waveShaper:          'WaveShaper',

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -43,7 +43,7 @@ export type StubKind =
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
 	// — Processing —
-	| 'channel' | 'panner3d'
+	| 'channel'
 	| 'convolver'
 	// — Analysis —
 	| 'recorder'
@@ -466,6 +466,20 @@ export type CrossFadeNodeData = {
 };
 export type CrossFadeFlowNode = Node<CrossFadeNodeData, 'crossFade'>;
 
+// v1 UI exposes only position + panningModel (docs/node-roadmap.md) — the
+// listener-cone/distance-falloff params (orientationX/Y/Z, distanceModel,
+// refDistance, maxDistance, rolloffFactor, coneInnerAngle/OuterAngle/
+// OuterGain) stay at their Tone.js defaults, ~14 controls is too heavy for v1.
+export type Panner3DPanningModel = 'equalpower' | 'HRTF';
+export type Panner3DNodeData = {
+	label:        string;
+	positionX:    number;   // default 0
+	positionY:    number;   // default 0
+	positionZ:    number;   // default 0
+	panningModel: Panner3DPanningModel; // default 'equalpower'
+};
+export type Panner3DFlowNode = Node<Panner3DNodeData, 'panner3d'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
@@ -606,6 +620,7 @@ export type AppNode =
 	| SoloFlowNode
 	| PannerFlowNode
 	| CrossFadeFlowNode
+	| Panner3DFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
@@ -766,6 +781,7 @@ export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: Multi
 export type SoloAudioEntry        = { kind: 'solo';        toneNode: Solo };
 export type PannerAudioEntry      = { kind: 'panner';      toneNode: Panner; split: Split };
 export type CrossFadeAudioEntry   = { kind: 'crossFade';   toneNode: CrossFade };
+export type Panner3DAudioEntry    = { kind: 'panner3d';    toneNode: Panner3D };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
@@ -834,6 +850,7 @@ export type AudioNodeEntry =
 	| SoloAudioEntry
 	| PannerAudioEntry
 	| CrossFadeAudioEntry
+	| Panner3DAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry


### PR DESCRIPTION
## Summary
- Implements `Panner3D` (Tier 3), wrapping Tone's `Panner3D` (itself a wrapper around the native Web Audio `PannerNode`).
- Per the roadmap's scope call, v1 UI exposes only `positionX/Y/Z` + `panningModel` — the listener-cone/distance-falloff params (`orientationX/Y/Z`, `distanceModel`, `refDistance`, `maxDistance`, `rolloffFactor`, `coneInnerAngle/OuterAngle/OuterGain`) stay at Tone.js defaults rather than exposing ~14 live controls.
- `positionX/Y/Z` are `Param<"number">` (`.value` write); `panningModel` is a plain getter/setter.
- `.input`/`.output` on `Panner3D` are the native `PannerNode`, but `Panner3D` still extends `ToneAudioNode`, so `genericAdapter` handles routing correctly.

## Merge order
Stacked branch: this PR targets `worktree-tier3-multibandcompressor`, stacking on the full chain: #26 (Solo) → #27 (CrossFade+Panner) → #28 (MidSideCompressor) → #29 (MultibandCompressor) → this PR.

## Test plan
- [x] `npx tsc --noEmit` — 17 pre-existing errors + 1 new (the same known MUI `MenuProps` Select-typing bug already reproduced in `FilterNode.tsx`, not a regression)
- [x] `npm run build` — clean
- [ ] Manual: add a Panner3D node, verify position sliders and panningModel dropdown affect the stereo image

🤖 Generated with [Claude Code](https://claude.com/claude-code)