### PR TITLE
Implement WaveShaper: Tier 3 batch 6

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -202,6 +202,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	negate:           genericAdapter,
 	audioToGain:      genericAdapter,
 	gainToAudio:      genericAdapter,
+	waveShaper:       genericAdapter,
 };
 
 // ─── Audio routing ────────────────────────────────────────────────────────────

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -64,6 +64,7 @@ import { pannerHandler }           from './nodes/panner';
 import { midSideCompressorHandler } from './nodes/midSideCompressor';
 import { multibandCompressorHandler } from './nodes/multibandCompressor';
 import { panner3dHandler } from './nodes/panner3d';
+import { waveShaperHandler } from './nodes/waveShaper';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -156,3 +157,4 @@ nodeRegistry.register('panner',           pannerHandler);
 nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
 nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
 nodeRegistry.register('panner3d', panner3dHandler);
+nodeRegistry.register('waveShaper', waveShaperHandler);

--- a/src/audio/nodes/waveShaper.ts
+++ b/src/audio/nodes/waveShaper.ts
@@ -1,0 +1,35 @@
+import { WaveShaper } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { WaveShaperNodeData, WaveShaperPreset } from '../../store/dawTypes';
+
+// Named curves standing in for a real curve editor (docs/adr/0005-waveshaper-preset-driven.md).
+const PRESET_MAPPINGS: Record<WaveShaperPreset, (value: number) => number> = {
+	identity: value => value,
+	softClip: value => Math.tanh(value * 2),
+	hardClip: value => Math.max(-1, Math.min(1, value * 3)),
+};
+
+export const waveShaperHandler: NodeTypeHandler<WaveShaperNodeData> = {
+	defaultData: { label: 'WaveShaper', preset: 'identity', oversample: 'none' },
+
+	create(id, data) {
+		const toneNode = new WaveShaper(PRESET_MAPPINGS[data.preset], 1024);
+		toneNode.oversample = data.oversample;
+		_audioNodes.set(id, { kind: 'waveShaper', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'waveShaper') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'waveShaper') return;
+		if (update.preset     !== undefined) e.toneNode.setMap(PRESET_MAPPINGS[update.preset]);
+		if (update.oversample !== undefined) e.toneNode.oversample = update.oversample;
+	},
+};

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -116,6 +116,7 @@ import { AbsNode }                from './nodes/signal/AbsNode';
 import { NegateNode }             from './nodes/signal/NegateNode';
 import { AudioToGainNode }        from './nodes/signal/AudioToGainNode';
 import { GainToAudioNode }        from './nodes/signal/GainToAudioNode';
+import { WaveShaperNode }         from './nodes/signal/WaveShaperNode';
 import { DeletableEdge }    from './edges/DeletableEdge';
 import { AddNodePanel }     from './panels/AddNodePanel';
 import { PatchPanel }      from './panels/PatchPanel';
@@ -191,6 +192,7 @@ const nodeTypes = {
 	negate:           NegateNode,
 	audioToGain:      AudioToGainNode,
 	gainToAudio:      GainToAudioNode,
+	waveShaper:       WaveShaperNode,
 };
 
 const edgeTypes = {

--- a/src/daw/nodes/signal/WaveShaperNode.tsx
+++ b/src/daw/nodes/signal/WaveShaperNode.tsx
@@ -1,0 +1,56 @@
+import { memo, useMemo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import ToggleButton from '@mui/material/ToggleButton';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx } from '../shared/hwStyles';
+import { HwToggleButtonGroup } from '../shared/hwComponents';
+import type { WaveShaperFlowNode, WaveShaperPreset } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.utility;
+const PRESETS: { value: WaveShaperPreset; label: string }[] = [
+	{ value: 'identity', label: 'identity' },
+	{ value: 'softClip', label: 'soft clip' },
+	{ value: 'hardClip', label: 'hard clip' },
+];
+const OVERSAMPLE_OPTIONS = ['none', '2x', '4x'] as const;
+
+export const WaveShaperNode = memo(function WaveShaperNode({ id, data, selected }: NodeProps<WaveShaperFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const sx = useMemo(() => ({
+		select:     hwSelectSx(color, 'small'),
+		selectMenu: hwSelectMenuProps(color),
+		menuItem:   hwMenuItemSx(color),
+	}), []);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='WaveShaper' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Select value={data.preset} onChange={e => setNodeParam(id, { preset: e.target.value as WaveShaperPreset })} fullWidth
+					sx={sx.select} MenuProps={sx.selectMenu}>
+					{PRESETS.map(p => (
+						<MenuItem key={p.value} value={p.value} sx={sx.menuItem}>{p.label}</MenuItem>
+					))}
+				</Select>
+				<HwToggleButtonGroup color={color} value={data.oversample} exclusive
+					onChange={(_, v) => v && setNodeParam(id, { oversample: v })} className='nodrag'>
+					{OVERSAMPLE_OPTIONS.map(opt => (
+						<ToggleButton key={opt} value={opt}>{opt}</ToggleButton>
+					))}
+				</HwToggleButtonGroup>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -489,6 +489,7 @@ const REAL_ACTIONS = new Set<string>([
 	'crossFade',
 	'panner',
 	'panner3d',
+	'waveShaper',
 	'midSideCompressor',
 	'multibandCompressor',
 ]);

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -110,7 +110,6 @@ const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
-	waveShaper:          'WaveShaper',
 	greaterThan:         'GreaterThan',
 	toneEvent:           'ToneEvent',
 };

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -49,7 +49,7 @@ export type StubKind =
 	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
 	// — Signal —
-	| 'waveShaper' | 'add' | 'multiply' | 'greaterThan'
+	| 'add' | 'multiply' | 'greaterThan'
 	// — Event —
 	| 'loop' | 'sequence' | 'pattern' | 'part' | 'toneEvent';
 
@@ -565,6 +565,18 @@ export type AudioToGainFlowNode = Node<AudioToGainNodeData, 'audioToGain'>;
 export type GainToAudioNodeData = { label: string };
 export type GainToAudioFlowNode = Node<GainToAudioNodeData, 'gainToAudio'>;
 
+// WaveShaper's mapping is a JS function/array, not a slider-able value — the
+// dropdown's value is a preset *name* stored purely for serialization/redraw;
+// selecting one triggers an imperative setMap() rather than a watched param
+// (docs/adr/0005-waveshaper-preset-driven.md).
+export type WaveShaperPreset = 'identity' | 'softClip' | 'hardClip';
+export type WaveShaperNodeData = {
+	label:      string;
+	preset:     WaveShaperPreset;         // default 'identity'
+	oversample: 'none' | '2x' | '4x';     // default 'none'
+};
+export type WaveShaperFlowNode = Node<WaveShaperNodeData, 'waveShaper'>;
+
 export type AppNode =
 	| BuiltInNode
 	| PlayerFlowNode
@@ -633,7 +645,8 @@ export type AppNode =
 	| AbsFlowNode
 	| NegateFlowNode
 	| AudioToGainFlowNode
-	| GainToAudioFlowNode;
+	| GainToAudioFlowNode
+	| WaveShaperFlowNode;
 
 export type AppEdge = Edge;
 
@@ -795,6 +808,7 @@ export type AbsAudioEntry         = { kind: 'abs';         toneNode: Abs };
 export type NegateAudioEntry      = { kind: 'negate';      toneNode: Negate };
 export type AudioToGainAudioEntry = { kind: 'audioToGain'; toneNode: AudioToGain };
 export type GainToAudioAudioEntry = { kind: 'gainToAudio'; toneNode: GainToAudio };
+export type WaveShaperAudioEntry  = { kind: 'waveShaper';  toneNode: WaveShaper };
 
 // Stubs are NOT in the audio registry — they have no Tone.js instances yet.
 
@@ -863,7 +877,8 @@ export type AudioNodeEntry =
 	| AbsAudioEntry
 	| NegateAudioEntry
 	| AudioToGainAudioEntry
-	| GainToAudioAudioEntry;
+	| GainToAudioAudioEntry
+	| WaveShaperAudioEntry;
 
 export type AudioNodeMap = Map<string, AudioNodeEntry>;
 


### PR DESCRIPTION
## Summary
- Implements `WaveShaper` (Tier 3), establishing the preset-driven dropdown pattern from ADR-0005.
- `WaveShaper.mapping` is a JS function/array, not a slider-able value, so v1 ships three named curve presets — **identity**, **soft clip** (`tanh(v*2)`), **hard clip** (driven clamp) — selected via a dropdown whose value is a preset *name* stored purely for serialization/redraw. Selecting a preset triggers an imperative `setMap()` call rather than setting a watched Tone param directly, unlike every other dropdown built so far (e.g. Filter's `type` selector).
- `oversample` (none/2x/4x) is a live setter, reusing the existing toggle-group pattern from `DistortionNode.tsx`.
- `.input`/`.output` are the native `WaveShaperNode`, but `WaveShaper` still extends `ToneAudioNode` via `SignalOperator`, so `genericAdapter` applies.

## Merge order
Stacked branch: this PR targets `worktree-tier3-panner3d`, stacking on the full chain: #26 (Solo) → #27 (CrossFade+Panner) → #28 (MidSideCompressor) → #29 (MultibandCompressor) → #31 (Panner3D) → this PR.

## Test plan
- [x] `npx tsc --noEmit` — 18 pre-existing errors + 2 new, both the same known MUI `Select`/`HwToggleButtonGroup` typing bugs already reproduced in `FilterNode.tsx`/`DistortionNode.tsx`, not regressions
- [x] `npm run build` — clean
- [ ] Manual: add a WaveShaper node, verify each preset audibly changes the shaping and oversample toggles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)