### PR TITLE
Implement Recorder: Tier 3 batch 7

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -195,6 +195,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	waveform:         genericAdapter,
 	analyser:         genericAdapter,
 	follower:         genericAdapter,
+	recorder:         genericAdapter,
 	signal:           genericAdapter,
 	scale:            genericAdapter,
 	scaleExp:         genericAdapter,

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -173,3 +173,7 @@ export { getDCMeterValue } from './nodes/dcMeter';
 export { getWaveformValue } from './nodes/waveform';
 export { getAnalyserValue } from './nodes/analyser';
 export { setSoloed } from './nodes/solo';
+
+export {
+	isRecorderSupported, startRecordingNode, pauseRecordingNode, stopRecordingNode, getRecorderState,
+} from './nodes/recorder';

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -65,6 +65,7 @@ import { midSideCompressorHandler } from './nodes/midSideCompressor';
 import { multibandCompressorHandler } from './nodes/multibandCompressor';
 import { panner3dHandler } from './nodes/panner3d';
 import { waveShaperHandler } from './nodes/waveShaper';
+import { recorderHandler } from './nodes/recorder';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -158,3 +159,4 @@ nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
 nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
 nodeRegistry.register('panner3d', panner3dHandler);
 nodeRegistry.register('waveShaper', waveShaperHandler);
+nodeRegistry.register('recorder', recorderHandler);

--- a/src/audio/nodes/recorder.ts
+++ b/src/audio/nodes/recorder.ts
@@ -1,0 +1,67 @@
+import { Recorder, start as toneStart } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { RecorderNodeData, RecorderAudioEntry } from '../../store/dawTypes';
+
+// ─── Recorder node ────────────────────────────────────────────────────────────
+// No live params (docs/adr/0006-recorder-v1-interaction-scope.md): mimeType is
+// constructor-only on Tone's Recorder, so v1 skips it entirely rather than
+// rebuilding the toneNode on every change. Sink topology — in-0 only, no
+// output. Own start/pause/stop lifecycle functions below, called directly by
+// the node's UI, mirroring player.ts's playNode/pauseNode/seekNode precedent
+// rather than threading record/pause/stop-with-blob through the shared
+// NodeTypeHandler.start/stop protocol (reserved for single-use-source restart).
+
+function getEntry(id: string): RecorderAudioEntry | undefined {
+	const e = _audioNodes.get(id);
+	return e?.kind === 'recorder' ? e : undefined;
+}
+
+export const recorderHandler: NodeTypeHandler<RecorderNodeData> = {
+	defaultData: { label: 'Recorder' },
+
+	create(id) {
+		const toneNode = new Recorder();
+		_audioNodes.set(id, { kind: 'recorder', toneNode });
+	},
+
+	dispose(id) {
+		const entry = getEntry(id);
+		if (!entry) return;
+		if (entry.toneNode.state === 'started') entry.toneNode.stop().catch(() => {});
+		entry.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam() { /* no live params — see ADR-0006 */ },
+};
+
+// ─── Recording operations ──────────────────────────────────────────────────────
+
+export function isRecorderSupported(): boolean {
+	return Recorder.supported;
+}
+
+export async function startRecordingNode(id: string): Promise<void> {
+	const entry = getEntry(id);
+	if (!entry) return;
+	await toneStart();
+	await entry.toneNode.start();
+}
+
+export function pauseRecordingNode(id: string): void {
+	const entry = getEntry(id);
+	if (!entry) return;
+	entry.toneNode.pause();
+}
+
+export async function stopRecordingNode(id: string): Promise<Blob | null> {
+	const entry = getEntry(id);
+	if (!entry) return null;
+	return entry.toneNode.stop();
+}
+
+export function getRecorderState(id: string): 'started' | 'stopped' | 'paused' {
+	const entry = getEntry(id);
+	return entry?.toneNode.state ?? 'stopped';
+}

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -109,6 +109,7 @@ import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
 import { WaveformNode }           from './nodes/analysis/WaveformNode';
 import { AnalyserNode }           from './nodes/analysis/AnalyserNode';
 import { FollowerNode }           from './nodes/analysis/FollowerNode';
+import { RecorderNode }           from './nodes/analysis/RecorderNode';
 import { SignalNode }             from './nodes/signal/SignalNode';
 import { ScaleNode }              from './nodes/signal/ScaleNode';
 import { ScaleExpNode }           from './nodes/signal/ScaleExpNode';
@@ -185,6 +186,7 @@ const nodeTypes = {
 	waveform:         WaveformNode,
 	analyser:         AnalyserNode,
 	follower:         FollowerNode,
+	recorder:         RecorderNode,
 	signal:           SignalNode,
 	scale:            ScaleNode,
 	scaleExp:         ScaleExpNode,

--- a/src/daw/nodes/analysis/RecorderNode.tsx
+++ b/src/daw/nodes/analysis/RecorderNode.tsx
@@ -1,0 +1,145 @@
+import { memo, useEffect, useRef, useState } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import PauseIcon from '@mui/icons-material/Pause';
+import StopIcon from '@mui/icons-material/Stop';
+import DownloadIcon from '@mui/icons-material/Download';
+import {
+	isRecorderSupported, startRecordingNode, pauseRecordingNode, stopRecordingNode,
+} from '../../../audio/engine';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwIconBtn, hwIconBtnLit } from '../shared/hwStyles';
+import type { RecorderFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.utility;
+
+function formatDuration(seconds: number): string {
+	const m = Math.floor(seconds / 60);
+	const s = Math.floor(seconds % 60);
+	return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function formatSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Persistent Download button, not auto-download on stop — the user decides
+// when (or whether) the take leaves the browser (docs/adr/0006-recorder-v1-
+// interaction-scope.md). No live params either: mimeType is constructor-only
+// on Tone's Recorder, so this node has no editable data at all.
+export const RecorderNode = memo(function RecorderNode({ id, selected }: NodeProps<RecorderFlowNode>) {
+	const supported = isRecorderSupported();
+
+	const [state, setState]       = useState<'idle' | 'recording' | 'paused' | 'stopped'>('idle');
+	const [elapsed, setElapsed]   = useState(0);
+	const [blobUrl, setBlobUrl]   = useState<string | null>(null);
+	const [blobSize, setBlobSize] = useState(0);
+	const [finalDuration, setFinalDuration] = useState(0);
+
+	const startedAtRef = useRef(0);
+	const accumRef      = useRef(0);
+	const rafRef        = useRef(0);
+	const blobUrlRef    = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (state !== 'recording') return;
+		startedAtRef.current = performance.now();
+		const tick = () => {
+			setElapsed(accumRef.current + (performance.now() - startedAtRef.current) / 1000);
+			rafRef.current = requestAnimationFrame(tick);
+		};
+		rafRef.current = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(rafRef.current);
+	}, [state]);
+
+	useEffect(() => () => { if (blobUrlRef.current) URL.revokeObjectURL(blobUrlRef.current); }, []);
+
+	const handleRecord = async () => {
+		if (state === 'stopped' && blobUrlRef.current) {
+			URL.revokeObjectURL(blobUrlRef.current);
+			blobUrlRef.current = null;
+			setBlobUrl(null);
+			accumRef.current = 0;
+			setElapsed(0);
+		}
+		await startRecordingNode(id);
+		setState('recording');
+	};
+
+	const handlePause = () => {
+		accumRef.current = elapsed;
+		pauseRecordingNode(id);
+		setState('paused');
+	};
+
+	const handleStop = async () => {
+		if (state === 'recording') accumRef.current = elapsed;
+		const blob = await stopRecordingNode(id);
+		setFinalDuration(accumRef.current);
+		setState('stopped');
+		if (blob) {
+			const url = URL.createObjectURL(blob);
+			blobUrlRef.current = url;
+			setBlobUrl(url);
+			setBlobSize(blob.size);
+		}
+	};
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Recorder' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75, alignItems: 'center' }} className='nodrag'>
+				{!supported ? (
+					<Typography variant='caption' color='text.disabled' sx={{ fontSize: 9, textAlign: 'center' }}>
+						MediaRecorder not supported in this browser
+					</Typography>
+				) : (
+					<>
+						<Box sx={{ display: 'flex', gap: 0.75 }}>
+							<IconButton size='small' disabled={state === 'recording'} onClick={handleRecord}
+								sx={state === 'recording' ? { ...hwIconBtnLit(color), p: 0.75 } : { ...hwIconBtn(color), p: 0.75 }}>
+								<FiberManualRecordIcon sx={{ fontSize: 16 }} />
+							</IconButton>
+							<IconButton size='small' disabled={state !== 'recording' && state !== 'paused'} onClick={handlePause}
+								sx={state === 'paused' ? { ...hwIconBtnLit(color), p: 0.75 } : { ...hwIconBtn(color), p: 0.75 }}>
+								<PauseIcon sx={{ fontSize: 16 }} />
+							</IconButton>
+							<IconButton size='small' disabled={state !== 'recording' && state !== 'paused'} onClick={handleStop}
+								sx={{ ...hwIconBtn(color), p: 0.75 }}>
+								<StopIcon sx={{ fontSize: 16 }} />
+							</IconButton>
+						</Box>
+
+						<Typography variant='caption' color='text.secondary' sx={{ fontSize: 11, fontFamily: 'monospace' }}>
+							{formatDuration(state === 'stopped' ? finalDuration : elapsed)}
+						</Typography>
+
+						{state === 'stopped' && blobUrl && (
+							<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25 }}>
+								<Typography variant='caption' color='text.disabled' sx={{ fontSize: 9 }}>
+									{formatSize(blobSize)}
+								</Typography>
+								<IconButton size='small' component='a' href={blobUrl} download={`recording-${id}.webm`}
+									sx={{ ...hwIconBtn(color), p: 0.75 }}>
+									<DownloadIcon sx={{ fontSize: 16 }} />
+								</IconButton>
+							</Box>
+						)}
+					</>
+				)}
+			</Box>
+
+			<Handle type='target' position={Position.Left} id='in-0' style={inputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -490,6 +490,7 @@ const REAL_ACTIONS = new Set<string>([
 	'panner',
 	'panner3d',
 	'waveShaper',
+	'recorder',
 	'midSideCompressor',
 	'multibandCompressor',
 ]);

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper, Recorder } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -46,7 +46,6 @@ export type StubKind =
 	| 'channel'
 	| 'convolver'
 	// — Analysis —
-	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
 	// — Signal —
 	| 'add' | 'multiply' | 'greaterThan'
@@ -530,6 +529,13 @@ export type FollowerNodeData = {
 };
 export type FollowerFlowNode = Node<FollowerNodeData, 'follower'>;
 
+// Sink — in-0 only, no output, cannot chain further downstream. No live params
+// (mimeType is constructor-only on Tone's Recorder — see ADR-0006); recording
+// state/blob live in the audio entry and component-local UI state, driven by
+// recorder.ts's own start/pause/stop functions, not setAudioParam.
+export type RecorderNodeData = { label: string };
+export type RecorderFlowNode = Node<RecorderNodeData, 'recorder'>;
+
 // ─── Signal node data types ────────────────────────────────────────────────────
 
 export type SignalNodeData = {
@@ -639,6 +645,7 @@ export type AppNode =
 	| WaveformFlowNode
 	| AnalyserFlowNode
 	| FollowerFlowNode
+	| RecorderFlowNode
 	| SignalFlowNode
 	| ScaleFlowNode
 	| ScaleExpFlowNode
@@ -801,6 +808,7 @@ export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
 export type WaveformAudioEntry    = { kind: 'waveform';    toneNode: Waveform };
 export type AnalyserAudioEntry    = { kind: 'analyser';    toneNode: Analyser };
 export type FollowerAudioEntry    = { kind: 'follower';    toneNode: Follower };
+export type RecorderAudioEntry    = { kind: 'recorder';    toneNode: Recorder };
 export type SignalNodeAudioEntry  = { kind: 'signal';      toneNode: Signal<'number'> };
 export type ScaleAudioEntry       = { kind: 'scale';       toneNode: Scale };
 export type ScaleExpAudioEntry    = { kind: 'scaleExp';    toneNode: ScaleExp };
@@ -871,6 +879,7 @@ export type AudioNodeEntry =
 	| WaveformAudioEntry
 	| AnalyserAudioEntry
 	| FollowerAudioEntry
+	| RecorderAudioEntry
 	| SignalNodeAudioEntry
 	| ScaleAudioEntry
 	| ScaleExpAudioEntry


### PR DESCRIPTION
## Summary
- Implements `Recorder` (Tier 3), a genuine sink node — `in-0` only, no output handle, cannot chain further downstream.
- Per ADR-0006's three v1 cuts:
  - **No live `mimeType` control** — Tone's `Recorder.mimeType` is constructor-only, so v1 just does `new Recorder()` with the browser-default format rather than rebuilding the `toneNode` on every change.
  - **Persistent Download button, not auto-download** — unlike Tone.js's own documented example (anchor + `.click()` the instant `stop()` resolves), the user gets a Download button and decides when the take leaves the browser.
  - **Own start/pause/stop lifecycle functions** in `recorder.ts`, called directly by `RecorderNode.tsx`, mirroring `player.ts`'s `playNode`/`pauseNode`/`seekNode` precedent rather than threading record/pause/stop-with-blob through the shared `NodeTypeHandler.start`/`stop` protocol.
- UI gates entirely on `Recorder.supported`; shows a record/pause/stop button row with a live elapsed-time readout, and a size readout + Download anchor after stop. Starting a new take revokes the previous blob URL.

## Merge order
Stacked branch: this PR targets `worktree-tier3-waveshaper`, stacking on the full chain: #26 (Solo) → #27 (CrossFade+Panner) → #28 (MidSideCompressor) → #29 (MultibandCompressor) → #31 (Panner3D) → #32 (WaveShaper) → this PR.

## Test plan
- [x] `npx tsc --noEmit` — 20 pre-existing errors, 0 new
- [x] `npm run build` — clean
- [ ] Manual: add a Recorder node, wire a source into it, record a few seconds, pause/resume, stop, and confirm the Download button produces a playable file

🤖 Generated with [Claude Code](https://claude.com/claude-code)