### PR TITLE
Implement Channel: Tier 3 batch 8, final Tier 3 node

### DIFF
--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -186,6 +186,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	filter:           genericAdapter,
 	eq3:              genericAdapter,
 	panVol:           genericAdapter,
+	channel:          genericAdapter,
 	mono:             genericAdapter,
 	volume:           genericAdapter,
 	solo:             genericAdapter,

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -66,6 +66,7 @@ import { multibandCompressorHandler } from './nodes/multibandCompressor';
 import { panner3dHandler } from './nodes/panner3d';
 import { waveShaperHandler } from './nodes/waveShaper';
 import { recorderHandler } from './nodes/recorder';
+import { channelHandler } from './nodes/channel';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -160,3 +161,4 @@ nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
 nodeRegistry.register('panner3d', panner3dHandler);
 nodeRegistry.register('waveShaper', waveShaperHandler);
 nodeRegistry.register('recorder', recorderHandler);
+nodeRegistry.register('channel', channelHandler);

--- a/src/audio/nodes/channel.ts
+++ b/src/audio/nodes/channel.ts
@@ -1,0 +1,33 @@
+import { Channel } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { ChannelNodeData } from '../../store/dawTypes';
+
+// Solo state is NOT threaded through here — Channel and Solo share Tone's own
+// static solo registry, and which instance is soloed is store-driven (daw.ts's
+// soloedNodeId, ADR-0003), set via setSoloed() in solo.ts, not through
+// setAudioParam. See ChannelNodeData's comment in dawTypes.ts.
+
+export const channelHandler: NodeTypeHandler<ChannelNodeData> = {
+	defaultData: { label: 'Channel', volume: 0, pan: 0, mute: false },
+
+	create(id, data) {
+		const toneNode = new Channel({ volume: data.volume, pan: data.pan, mute: data.mute });
+		_audioNodes.set(id, { kind: 'channel', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'channel') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'channel') return;
+		if (update.volume !== undefined) e.toneNode.volume.value = update.volume;
+		if (update.pan    !== undefined) e.toneNode.pan.value    = update.pan;
+		if (update.mute   !== undefined) e.toneNode.mute          = update.mute;
+	},
+};

--- a/src/audio/nodes/solo.ts
+++ b/src/audio/nodes/solo.ts
@@ -5,7 +5,10 @@ import type { SoloNodeData } from '../../store/dawTypes';
 
 // Solo has no configurable params exposed through the generic setNodeParam
 // path — which instance is soloed is store-driven (daw.ts's soloedNodeId,
-// ADR-0003), set via setSoloed() below, not through NodeTypeHandler.
+// ADR-0003), set via setSoloed() below, not through NodeTypeHandler. Channel
+// (src/audio/nodes/channel.ts) shares Tone's own static solo registry with
+// Solo, so setSoloed() below handles both entry kinds rather than duplicating
+// this function there.
 
 export const soloHandler: NodeTypeHandler<SoloNodeData> = {
 	defaultData: { label: 'Solo' },
@@ -30,6 +33,6 @@ export const soloHandler: NodeTypeHandler<SoloNodeData> = {
 /** Solos or unsolos this instance. Tone's own static registry mutes every other Solo/Channel instance in the context. */
 export function setSoloed(id: string, soloed: boolean): void {
 	const e = _audioNodes.get(id);
-	if (e?.kind !== 'solo') return;
+	if (e?.kind !== 'solo' && e?.kind !== 'channel') return;
 	e.toneNode.solo = soloed;
 }

--- a/src/audio/nodes/stub.ts
+++ b/src/audio/nodes/stub.ts
@@ -2,7 +2,7 @@ import type { NodeTypeHandler } from './nodeHandler';
 import type { StubNodeData } from '../../store/dawTypes';
 
 export const stubHandler: NodeTypeHandler<StubNodeData> = {
-	defaultData: { label: 'Stub', kind: 'channel' },
+	defaultData: { label: 'Stub', kind: 'convolver' },
 	create()        { /* not yet implemented */ },
 	dispose()       { /* not yet implemented */ },
 	setAudioParam() { /* not yet implemented */ },

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -94,6 +94,7 @@ import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
 import { FilterNode }             from './nodes/processing/FilterNode';
 import { EQ3Node }                from './nodes/processing/EQ3Node';
 import { PanVolNode }             from './nodes/processing/PanVolNode';
+import { ChannelNode }            from './nodes/processing/ChannelNode';
 import { SplitNode }              from './nodes/processing/SplitNode';
 import { MergeNode }              from './nodes/processing/MergeNode';
 import { MonoNode }               from './nodes/processing/MonoNode';
@@ -171,6 +172,7 @@ const nodeTypes = {
 	filter:           FilterNode,
 	eq3:              EQ3Node,
 	panVol:           PanVolNode,
+	channel:          ChannelNode,
 	split:            SplitNode,
 	merge:            MergeNode,
 	mono:             MonoNode,

--- a/src/daw/nodes/processing/ChannelNode.tsx
+++ b/src/daw/nodes/processing/ChannelNode.tsx
@@ -1,0 +1,46 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwSwitch } from '../shared/hwComponents';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { ChannelFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+
+// PanVol + Solo internally composed (docs/node-roadmap.md). Solo state comes
+// from the store, not node data — same cross-instance pattern as SoloNode.tsx
+// (ADR-0003): Channel and Solo share Tone's own static solo registry, so
+// soloing this instance dims every other Solo/Channel node on the canvas.
+export const ChannelNode = memo(function ChannelNode({ id, data, selected }: NodeProps<ChannelFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const toggleSolo    = useDawStore(s => s.toggleSolo);
+	const soloedNodeId  = useDawStore(s => s.soloedNodeId);
+	const isSoloed       = soloedNodeId === id;
+	const isMutedByPeer  = soloedNodeId !== null && !isSoloed;
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', opacity: isMutedByPeer ? 0.55 : 1, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Channel' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='pan'    value={data.pan}    min={-1}  max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { pan: v })}    format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='volume' value={data.volume} min={-60} max={6} step={0.5}  color={color} onChange={v => setNodeParam(id, { volume: v })} format={v => v.toFixed(1)} unit='dB' allowValueEdit allowBoundsEdit />
+				</Box>
+				<Box sx={{ display: 'flex', gap: 1.5, justifyContent: 'center' }}>
+					<HwSwitch checked={data.mute} color={color} onChange={() => setNodeParam(id, { mute: !data.mute })} label='mute' />
+					<HwSwitch checked={isSoloed}  color={color} onChange={() => toggleSolo(id)}                          label='solo' />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -493,6 +493,7 @@ const REAL_ACTIONS = new Set<string>([
 	'recorder',
 	'midSideCompressor',
 	'multibandCompressor',
+	'channel',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper, Recorder } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper, Recorder, Channel } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -43,7 +43,6 @@ export type StubKind =
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
 	// — Processing —
-	| 'channel'
 	| 'convolver'
 	// — Analysis —
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
@@ -419,6 +418,19 @@ export type PanVolNodeData = {
 };
 export type PanVolFlowNode = Node<PanVolNodeData, 'panVol'>;
 
+// Channel is PanVol + Solo internally composed (docs/node-roadmap.md) — solo
+// state is deliberately NOT a field here, same reasoning as SoloNodeData:
+// it's store-driven (daw.ts's soloedNodeId, ADR-0003) since Channel and Solo
+// share Tone's own static solo registry. send/receive bus routing is
+// permanently out of scope (docs/adr/0007-channel-send-receive-out-of-scope.md).
+export type ChannelNodeData = {
+	label:  string;
+	volume: number;    // dB, -60–6, default 0
+	pan:    number;    // -1–1, default 0
+	mute:   boolean;   // default false
+};
+export type ChannelFlowNode = Node<ChannelNodeData, 'channel'>;
+
 export type SplitNodeData = { label: string };
 export type SplitFlowNode = Node<SplitNodeData, 'split'>;
 
@@ -630,6 +642,7 @@ export type AppNode =
 	| FilterFlowNode
 	| EQ3FlowNode
 	| PanVolFlowNode
+	| ChannelFlowNode
 	| SplitFlowNode
 	| MergeFlowNode
 	| MonoFlowNode
@@ -793,6 +806,7 @@ export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFil
 export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
 export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
 export type PanVolAudioEntry      = { kind: 'panVol';      toneNode: PanVol };
+export type ChannelAudioEntry     = { kind: 'channel';     toneNode: Channel };
 export type SplitNodeAudioEntry   = { kind: 'split';       toneNode: Split };
 export type MergeNodeAudioEntry   = { kind: 'merge';       toneNode: Merge };
 export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
@@ -864,6 +878,7 @@ export type AudioNodeEntry =
 	| FilterAudioEntry
 	| EQ3AudioEntry
 	| PanVolAudioEntry
+	| ChannelAudioEntry
 	| SplitNodeAudioEntry
 	| MergeNodeAudioEntry
 	| MonoAudioEntry


### PR DESCRIPTION
## Summary
- Implements `Channel` (Tier 3) — the last of the 8 Tier 3 nodes. `Channel` is `PanVol` + `Solo` internally composed.
- Reuses `SoloNode`'s cross-instance solo pattern from ADR-0003 rather than threading solo state through node data: `Channel` and `Solo` share Tone's own static solo registry, so soloing a `Channel` instance dims every other `Solo`/`Channel` node on the canvas via `daw.ts`'s `soloedNodeId`. `solo.ts`'s `setSoloed()` now handles both `'solo'` and `'channel'` audio-entry kinds instead of duplicating the function in `channel.ts`.
- `send`/`receive` bus routing is permanently out of scope per ADR-0007 — it would let a `Channel` node be effectively wired to another node with nothing on the canvas showing it, which cuts against the whole point of a node-graph UI.
- `stub.ts`'s dead placeholder `StubKind` moves from `'channel'` to `'convolver'` now that `'channel'` is a real node type.

## Merge order
Stacked branch: this PR targets `worktree-tier3-recorder`, stacking on the full chain: #26 (Solo) → #27 (CrossFade+Panner) → #28 (MidSideCompressor) → #29 (MultibandCompressor) → #31 (Panner3D) → #32 (WaveShaper) → #33 (Recorder) → this PR. This is the final Tier 3 batch.

## Test plan
- [x] `npx tsc --noEmit` — 20 pre-existing errors, 0 new
- [x] `npm run build` — clean
- [ ] Manual: add two Channel nodes (or a Channel + a Solo node), verify soloing one dims/mutes the other and that pan/volume/mute controls work

🤖 Generated with [Claude Code](https://claude.com/claude-code)