### PR TITLE
Fix hwSelectMenuProps: PaperProps -> slotProps.paper

### DIFF
--- a/src/daw/nodes/shared/hwStyles.ts
+++ b/src/daw/nodes/shared/hwStyles.ts
@@ -165,13 +165,15 @@ export function hwMenuItemSx(color: string) {
 
 export function hwSelectMenuProps(color: string) {
 	return {
-		PaperProps: {
-			sx: {
-				background:   '#1a1a1e',
-				border:       '1px solid #0d0d0f',
-				borderColor:  `${color}40`,
-				boxShadow:    `0 4px 12px rgba(0,0,0,0.7), 0 0 0 1px ${color}20`,
-				'& .MuiMenuItem-root': hwMenuItemSx(color),
+		slotProps: {
+			paper: {
+				sx: {
+					background:   '#1a1a1e',
+					border:       '1px solid #0d0d0f',
+					borderColor:  `${color}40`,
+					boxShadow:    `0 4px 12px rgba(0,0,0,0.7), 0 0 0 1px ${color}20`,
+					'& .MuiMenuItem-root': hwMenuItemSx(color),
+				},
 			},
 		},
 	};


### PR DESCRIPTION
## Summary
- Fixes a pre-existing (not from Tier 3 work) runtime bug in `hwSelectMenuProps()`: it was passing `PaperProps` to MUI's `Select`/`Menu`, a shape the installed `@mui/material` version (9.3.1) no longer supports — Paper styling moved to `slotProps.paper`. This was already flagged as a TypeScript error across every Select-using node (Filter, Panner3D, WaveShaper, TrackSelector, BiquadFilter, analysis nodes), but browser testing confirmed it's also a real runtime console error every time any of those dropdowns open: `React does not recognize the PaperProps prop on a DOM element`.
- Found while doing a full browser verification pass of all node types on `next` after the Tier 3 merge.

## Test plan
- [x] `npx tsc --noEmit` — 9 errors remain (down from 20), all pre-existing and unrelated (`HwToggleButtonGroup`'s `color`-prop typing, `DawCanvas`'s `onNodeDragStop` typing); the entire `PaperProps`/`MenuProps` error class is gone
- [x] `npm run build` — clean
- [x] Manual: opened Panner3D's `panningModel` dropdown in the browser before and after — error present before, gone after, menu styling unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)