### PR TITLE
Fix remaining pre-existing tsc errors and Recorder start() hang

### DIFF
--- a/src/audio/nodes/recorder.ts
+++ b/src/audio/nodes/recorder.ts
@@ -46,7 +46,16 @@ export async function startRecordingNode(id: string): Promise<void> {
 	const entry = getEntry(id);
 	if (!entry) return;
 	await toneStart();
-	await entry.toneNode.start();
+	// The underlying MediaRecorder's `start` event only fires once audio data
+	// actually begins flowing through the stream -- an idle Recorder (nothing
+	// wired in yet, or a silent/unstarted source) never gets it, which would
+	// hang this forever even though the native recorder's .state already
+	// flips to "started" synchronously. Race a short timeout so the UI never
+	// gets stuck waiting on an event that may never arrive.
+	await Promise.race([
+		entry.toneNode.start().catch(() => {}),
+		new Promise<void>(resolve => setTimeout(resolve, 200)),
+	]);
 }
 
 export function pauseRecordingNode(id: string): void {

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -9,7 +9,6 @@ import {
 	useReactFlow,
 	applyNodeChanges,
 	type NodeChange,
-	type Node,
 } from '@xyflow/react';
 import { useShallow } from 'zustand/react/shallow';
 import Box from '@mui/material/Box';
@@ -451,7 +450,7 @@ export function DawCanvas(layout: LayoutControls) {
 		isDragging.current = true;
 	}, []);
 
-	const handleNodeDragStop = useCallback((_event: React.MouseEvent, _node: Node, nodes: AppNode[]) => {
+	const handleNodeDragStop = useCallback((_event: MouseEvent | TouchEvent, _node: AppNode, nodes: AppNode[]) => {
 		isDragging.current = false;
 		// Wrap in startTransition so the Zustand flush is treated as a low-priority
 		// update. Without this, the synchronous React commit blocks the main thread

--- a/src/daw/nodes/shared/hwComponents.tsx
+++ b/src/daw/nodes/shared/hwComponents.tsx
@@ -10,7 +10,7 @@ type HwToggleButtonGroupProps = {
 	color: string;
 	/** Number of equal-width columns. Omit for a horizontal strip layout. */
 	cols?: number;
-} & Omit<ToggleButtonGroupProps, 'sx'>;
+} & Omit<ToggleButtonGroupProps, 'sx' | 'color'>;
 
 export function HwToggleButtonGroup({ color, cols, children, ...props }: HwToggleButtonGroupProps) {
 	const sx = cols ? hwGridToggleSx(color, cols) : hwToggleSx(color);
@@ -26,8 +26,9 @@ type HwButtonProps = { color: string; lit?: boolean } & Omit<ButtonProps, 'color
 
 export function HwButton({ color, lit = false, sx: sxProp, children, ...props }: HwButtonProps) {
 	const base = lit ? hwBtnLit(color) : hwBtn(color);
+	const sx = sxProp ? [base, ...(Array.isArray(sxProp) ? sxProp : [sxProp])] : [base];
 	return (
-		<Button sx={sxProp ? [base, sxProp] : base} {...props}>
+		<Button sx={sx} {...props}>
 			{children}
 		</Button>
 	);


### PR DESCRIPTION
## Summary
Two independent fixes found and verified while doing a full browser pass over `next` before the eventual merge to `main`:

**Clear the last 9 pre-existing tsc errors** (none from Tier 1/2/3 work):
- `HwToggleButtonGroup`: wasn't omitting `color` from its `ToggleButtonGroupProps` intersection, so our own `color: string` prop got ANDed against MUI's palette-name union — rejected every real hex-string caller (Distortion, WaveShaper, NoiseGenerator, DebugNode). `color` is destructured out and never forwarded to the underlying component, so omitting it is correct, not just type-appeasement.
- `HwButton`: `sx={sxProp ? [base, sxProp] : base}` ternary produced a union MUI's `SxProps` type couldn't match. Always building an array (and flattening `sxProp` into it if it's itself already an array) fixes the type without changing the runtime merge.
- `DawCanvas`: `handleNodeDragStop`'s params were typed against React's `SyntheticEvent`/xyflow's generic `Node` instead of the actual `OnNodeDrag<AppNode>` signature ReactFlow calls it with. Both params are unused already, so this is type-only.

`tsc --noEmit` is now **0 errors** for the first time.

**Fix Recorder hanging forever on start() with nothing wired in**: `Tone.Recorder.start()`'s promise resolves on the native `MediaRecorder`'s `start` event, which only fires once actual audio data flows through the stream. A Recorder with nothing connected (or connected to a not-yet-started source) never gets it, hanging the UI's record button forever even though the native recorder's own `.state` already flips to "started" synchronously. Confirmed directly in the browser: a raw `MediaRecorder` on an idle `MediaStreamDestination` never fires `onstart` even after 3+ seconds; the same setup with an active oscillator connected fires it immediately. `stop()`'s event fires reliably either way. Fixed by racing `start()` against a 200ms timeout so the UI always progresses.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — clean
- [x] Manual: Distortion's oversample toggle group and Noise's start button (HwButton) both work; dragging a node still works
- [x] Manual: Recorder now flips to "recording" immediately regardless of what's wired in, elapsed timer ticks, Stop produces a valid downloadable blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)