### PR TITLE
Merge Tier 2 + Tier 3 node buildout into main

### DIFF
--- a/docs/adr/0001-shared-tap-readout-hook.md
+++ b/docs/adr/0001-shared-tap-readout-hook.md
@@ -1,11 +1,18 @@
-# Shared tap+readout hook for Analysis nodes
+# Shared tap+readout hook for canvas-drawing Analysis nodes
 
-Tier 1 shipped four Analysis nodes (FFT, Meter, DCMeter, Waveform) that each pass audio through
-unchanged and poll a `getValue()`-family method via their own `requestAnimationFrame` loop,
-duplicated near-identically across `FFTNode.tsx`/`MeterNode.tsx`/`DCMeterNode.tsx`/
-`WaveformNode.tsx`. Tier 2 adds a fifth, Analyser. Rather than add a fifth bespoke copy, we're
-extracting a shared hook that owns the rAF polling loop and returns the latest value; each node
-keeps its own draw/render logic (bar spectrum, line waveform, needle meter, etc. genuinely
-differ), and the four existing nodes get refactored onto it in the same batch. Five instances of
-the same polling loop is the point where the duplication risk (one copy silently drifting from
-the other four) outweighs the cost of the refactor touching already-shipped files.
+Tier 1 shipped four Analysis nodes that each pass audio through unchanged and poll a
+`getValue()`-family method for a live readout, but they split into two genuinely different
+rendering shapes, not one: FFT and Waveform each run their own `requestAnimationFrame` loop that
+draws straight to a `<canvas>`, bypassing React state entirely for frame-rate reasons; Meter and
+DCMeter instead poll via `setInterval(100ms)`, feeding a numeric readout and an `HwLevelMeter` bar
+through plain React state. On inspection these aren't one duplicated pattern, they're two — and
+only the first (FFT/Waveform) is what Analyser needs, since Analyser's `type` param toggles
+between drawing an FFT spectrum and a waveform line, i.e. it's the union of exactly what FFT and
+Waveform already each do.
+
+We're extracting a shared hook for the rAF+canvas shape only — it owns the polling loop and
+returns the latest value, each node keeps its own draw call (bar spectrum vs line trace) — and
+refactoring `FFTNode.tsx`/`WaveformNode.tsx` onto it alongside building `AnalyserNode.tsx` on the
+same hook. `MeterNode.tsx`/`DCMeterNode.tsx` are left as they are: forcing their
+setInterval+React-state pattern into the same abstraction as the canvas one would be unifying two
+things that only superficially look alike, not removing real duplication.

--- a/docs/adr/0001-shared-tap-readout-hook.md
+++ b/docs/adr/0001-shared-tap-readout-hook.md
@@ -1,0 +1,11 @@
+# Shared tap+readout hook for Analysis nodes
+
+Tier 1 shipped four Analysis nodes (FFT, Meter, DCMeter, Waveform) that each pass audio through
+unchanged and poll a `getValue()`-family method via their own `requestAnimationFrame` loop,
+duplicated near-identically across `FFTNode.tsx`/`MeterNode.tsx`/`DCMeterNode.tsx`/
+`WaveformNode.tsx`. Tier 2 adds a fifth, Analyser. Rather than add a fifth bespoke copy, we're
+extracting a shared hook that owns the rAF polling loop and returns the latest value; each node
+keeps its own draw/render logic (bar spectrum, line waveform, needle meter, etc. genuinely
+differ), and the four existing nodes get refactored onto it in the same batch. Five instances of
+the same polling loop is the point where the duplication risk (one copy silently drifting from
+the other four) outweighs the cost of the refactor touching already-shipped files.

--- a/docs/adr/0002-signal-math-nodes-slider-only-v1.md
+++ b/docs/adr/0002-signal-math-nodes-slider-only-v1.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# Add/Multiply/GreaterThan ship slider-only, not two-signal wiring
+
+Tone.js's second operand for `Add`, `Multiply`, and `GreaterThan` (`.addend`/`.factor`/
+`.comparator`) is a `Param`, not a second `InputNode` — a different attachment point than the
+`in-N → toneNode.input` convention every handler in `nodeHandler.ts` currently assumes. True
+two-signal wiring (a second handle connected directly to that `Param`) would be the more capable
+design, but it means widening the handle→input contract for the first time, which deserves its
+own deliberate design pass rather than landing incidentally inside a Tier 2 node batch. We're
+shipping v1 as a single audio-in handle + a value slider for the constant operand, matching
+`gain.ts`'s existing pattern exactly. Two-handle wiring to the `Param` remains a flagged, explicit
+future extension — not something to bolt on silently later.
+
+## Considered Options
+
+- **Two-handle wiring now** — rejected for this batch: changes a core handler contract
+  (`nodeHandler.ts`'s in-N→input assumption) as a side effect of routine node buildout, not as its
+  own reviewed decision.
+- **Slider-only v1** — chosen: ships fast, matches an established pattern, defers the contract
+  change to when it's deliberately designed.

--- a/docs/adr/0003-solo-cross-instance-state.md
+++ b/docs/adr/0003-solo-cross-instance-state.md
@@ -1,0 +1,18 @@
+# Solo's cross-instance mute state: store-driven, not polled
+
+Soloing one `Solo` node must mute every other `Solo`/`Channel` instance sharing the audio context.
+Tone.js already does this for free via its own internal static registry — that part needs no new
+code. What's new is that reactoscope's UI also needs every *other* node's displayed state to
+update in response, which no existing node does today (every other node's param changes are
+purely local to itself).
+
+We're keeping audio truth and UI truth in separate places: Tone's registry stays the source of
+truth for actual audio muting, and the `daw.ts` store gains a field tracking which node id (if
+any) is currently soloed. `SoloNode` (and later `Channel`) components read that store field to
+render other instances' dimmed/muted visual state, rather than polling Tone's internal registry
+on an interval the way the tap+readout nodes poll audio levels. Polling was the other option
+considered — it would have repurposed a pattern meant for continuous audio signals to track a
+discrete boolean toggle, and would have required exposing Tone's internal registry through
+`engine.ts`'s public surface, which it isn't today. This is the first node in the catalogue where
+one instance's param change needs to visibly affect other node components' displayed state; the
+same store-field pattern is expected to extend to `Channel`'s built-in solo behavior later.

--- a/docs/adr/0004-nested-param-panel-layout.md
+++ b/docs/adr/0004-nested-param-panel-layout.md
@@ -1,0 +1,15 @@
+# Nested param panels: side-by-side bands, not tabs
+
+MidSideCompressor and MultibandCompressor are reactoscope's first nodes whose Tone.js params
+naturally split into multiple named groups (mid/side, or low/mid/high bands) rather than one flat
+list — every existing node UI is a single column of sliders/dropdowns. We're rendering each band
+as its own labeled sub-panel, all shown side-by-side and always visible, rather than behind a tab
+switcher that reveals one band at a time. Tabs would keep the node body narrower, but every other
+node in the catalogue is direct-manipulation — every control is visible and editable without
+clicking through anything first — and hiding two-thirds of a node's params behind tabs would be
+the first departure from that. The node just gets wider instead, consistent with existing
+precedent (nodes already scale width by param count, e.g. FFT/BiquadFilter at 2.5× the grid unit).
+
+Each band reuses a new shared `CompressorControls` component (extracted from
+`CompressorNode.tsx`'s existing threshold/ratio/attack/release/knee slider row, parameterized by
+value+onChange per param) rather than each node hand-duplicating that row two or three more times.

--- a/docs/adr/0005-waveshaper-preset-driven.md
+++ b/docs/adr/0005-waveshaper-preset-driven.md
@@ -1,0 +1,17 @@
+# WaveShaper ships preset-driven, not a curve editor
+
+Tone.js's `WaveShaper.mapping` is a JS function or raw sample array, not a slider-able value —
+there's no numeric range to expose. v1 ships three named curve presets (identity, soft clip, hard
+clip) via a dropdown, plus a live `oversample` (none/2x/4x) setter. Building an actual curve editor
+(freehand or control-point curve drawing) is out of scope; presets cover the common
+distortion/saturation use case without inventing a new curve-editing UI from scratch.
+
+This establishes a pattern distinct from every other dropdown in the codebase. Filter's `type`
+dropdown, for example, is a live Tone.js `Param`/getter-setter the UI reads back and displays —
+the dropdown's value *is* the persisted state. WaveShaper's dropdown value is just a preset
+*name*, stored in node data purely for serialization/redraw; selecting a preset triggers an
+imperative `setMap()` call rather than setting a watched param directly. Worth recording explicitly
+so a future curve/shape-selection node (there's real precedent coming — Sampler's note-to-buffer
+mapping, Pattern's cycling algorithms) reuses this preset-name-drives-imperative-call shape rather
+than reinventing it, and so a reader diffing this against Filter's dropdown doesn't wonder why
+WaveShaper's "doesn't work like the others."

--- a/docs/adr/0006-recorder-v1-interaction-scope.md
+++ b/docs/adr/0006-recorder-v1-interaction-scope.md
@@ -1,0 +1,25 @@
+# Recorder v1: no live mimeType, no auto-download, own lifecycle functions
+
+Two related cuts to Recorder's v1 interaction, plus one wiring decision:
+
+**No live `mimeType` control.** Tone.js's `Recorder.mimeType` is a read-only getter — it's
+constructor-only, with no setter. A dropdown would mean disposing and recreating the whole
+`toneNode` on every change, the same rebuild machinery `oscillator.ts` and friends use for
+single-use sources. That's real complexity for a param the roadmap itself already called
+low-priority, so v1 skips it entirely: `new Recorder()` with no options, browser default format.
+
+**Persistent Download button, not auto-download.** `stop()` resolves with a `Blob`. Tone.js's own
+documented example immediately builds an anchor element and calls `.click()` on it — an
+instant browser download the moment recording stops. reactoscope shows a Download button plus a
+duration/size readout instead, left for the user to click on their own schedule. Every other
+action in the app is something the user explicitly does; a Stop button that silently triggers an
+OS-level save dialog as a side effect would be the first exception. This also means a user can
+keep the take around and decide whether to keep it before it leaves the browser.
+
+**Own lifecycle functions, not the shared handler protocol.** `startRecording`/`stopRecording`/
+`pauseRecording` live in `src/audio/nodes/recorder.ts` and are called directly by the node's UI
+component, not threaded through `NodeTypeHandler.start`/`stop` — that protocol is reserved for the
+single-use-source recreate-on-restart contract and doesn't fit record/pause/stop-with-blob-result.
+This mirrors existing precedent in `player.ts` (`playNode`/`pauseNode`/`seekNode` etc., called
+directly by `PlayerNode.tsx`, bypassing the generic handler path) rather than inventing a third
+shape.

--- a/docs/adr/0007-channel-send-receive-out-of-scope.md
+++ b/docs/adr/0007-channel-send-receive-out-of-scope.md
@@ -1,0 +1,16 @@
+# Channel's send/receive bus routing is permanently out of scope
+
+`Channel.send(name, volume)` / `receive(name)` let a node route audio to or from a named string
+bus, entirely outside the normal node-graph connection model — the audio actually flows, but no
+edge on the canvas represents it. reactoscope's node graph works on the invariant that every
+connection between two nodes is a visible edge; that's implicit in how the app works today, worth
+stating explicitly here because Channel is the first node whose underlying Tone.js class offers a
+way to break it.
+
+This is a boundary decision, not a v1 scope cut like the param-count reductions elsewhere in Tier
+3 (MultibandCompressor, Panner3D) — those are "less work for now, easy to add more sliders later."
+This one is "no," permanently: exposing send/receive would mean a Channel node could be
+effectively wired to another node with nothing on the canvas showing it, which cuts against the
+whole point of a node-graph UI. If bus routing turns out to be genuinely wanted later, it needs
+its own design as a visible graph concept (a bus node type, say), not a shortcut bolted onto
+Channel's param panel.

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -186,6 +186,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	filter:           genericAdapter,
 	eq3:              genericAdapter,
 	panVol:           genericAdapter,
+	channel:          genericAdapter,
 	mono:             genericAdapter,
 	volume:           genericAdapter,
 	solo:             genericAdapter,

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -180,6 +180,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	gate:             genericAdapter,
 	compressor:       genericAdapter,
 	midSideCompressor: genericAdapter,
+	multibandCompressor: genericAdapter,
 	biquadFilter:     genericAdapter,
 	filter:           genericAdapter,
 	eq3:              genericAdapter,

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -179,6 +179,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	limiter:          genericAdapter,
 	gate:             genericAdapter,
 	compressor:       genericAdapter,
+	midSideCompressor: genericAdapter,
 	biquadFilter:     genericAdapter,
 	filter:           genericAdapter,
 	eq3:              genericAdapter,

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -202,6 +202,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	negate:           genericAdapter,
 	audioToGain:      genericAdapter,
 	gainToAudio:      genericAdapter,
+	waveShaper:       genericAdapter,
 };
 
 // ─── Audio routing ────────────────────────────────────────────────────────────

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -147,6 +147,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	multibandSplit: multibandSplitAdapter,
 	crossFade:    crossFadeAdapter,
 	panner:       pannerAdapter,
+	panner3d:     genericAdapter,
 	oscillator:       genericAdapter,
 	gain:             genericAdapter,
 	noise:            genericAdapter,

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -168,6 +168,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	panVol:           genericAdapter,
 	mono:             genericAdapter,
 	volume:           genericAdapter,
+	solo:             genericAdapter,
 	fft:              genericAdapter,
 	meter:            genericAdapter,
 	dcMeter:          genericAdapter,

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -121,6 +121,21 @@ const multibandSplitAdapter: PortAdapter = {
 	},
 };
 
+const crossFadeAdapter: PortAdapter = {
+	// CrossFade: no single `.input` — in-0/in-1 wire directly to toneNode.a/.b.
+	getInput: (entry, targetHandle) =>
+		entry.kind === 'crossFade' ? { node: targetHandle === 'in-1' ? entry.toneNode.b : entry.toneNode.a, channel: 0 } : null,
+	getOutput: (entry) => entry.kind === 'crossFade' ? { node: entry.toneNode, channel: 0 } : null,
+};
+
+const pannerAdapter: PortAdapter = {
+	// Panner: plain StereoPannerNode input; out-0/out-1 select the internal
+	// Split(2)'s two channels, since Panner has no native separate L/R taps.
+	getInput: (entry) => entry.kind === 'panner' ? { node: entry.toneNode, channel: 0 } : null,
+	getOutput: (entry, sourceHandle) =>
+		entry.kind === 'panner' ? { node: entry.split, channel: sourceHandle === 'out-1' ? 1 : 0 } : null,
+};
+
 const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	masterOutput: masterOutputAdapter,
 	player:       splitOutputAdapter,
@@ -130,6 +145,8 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	split:        splitNodeAdapter,
 	merge:        mergeNodeAdapter,
 	multibandSplit: multibandSplitAdapter,
+	crossFade:    crossFadeAdapter,
+	panner:       pannerAdapter,
 	oscillator:       genericAdapter,
 	gain:             genericAdapter,
 	noise:            genericAdapter,

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -108,6 +108,19 @@ const mergeNodeAdapter: PortAdapter = {
 	getOutput: (entry) => entry.kind === 'merge' ? { node: entry.toneNode, channel: 0 } : null,
 };
 
+const multibandSplitAdapter: PortAdapter = {
+	// MultibandSplit: plain Gain input, but no single `.output` — out-0/1/2
+	// select the low/mid/high child Filter instances directly.
+	getInput: (entry) => entry.kind === 'multibandSplit' ? { node: entry.toneNode, channel: 0 } : null,
+	getOutput: (entry, sourceHandle) => {
+		if (entry.kind !== 'multibandSplit') return null;
+		const node = sourceHandle === 'out-1' ? entry.toneNode.mid
+			: sourceHandle === 'out-2' ? entry.toneNode.high
+			: entry.toneNode.low;
+		return { node, channel: 0 };
+	},
+};
+
 const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	masterOutput: masterOutputAdapter,
 	player:       splitOutputAdapter,
@@ -116,6 +129,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	delay:        delayAdapter,
 	split:        splitNodeAdapter,
 	merge:        mergeNodeAdapter,
+	multibandSplit: multibandSplitAdapter,
 	oscillator:       genericAdapter,
 	gain:             genericAdapter,
 	noise:            genericAdapter,
@@ -147,7 +161,10 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	autoWah:          genericAdapter,
 	limiter:          genericAdapter,
 	gate:             genericAdapter,
+	compressor:       genericAdapter,
 	biquadFilter:     genericAdapter,
+	filter:           genericAdapter,
+	eq3:              genericAdapter,
 	panVol:           genericAdapter,
 	mono:             genericAdapter,
 	volume:           genericAdapter,
@@ -155,6 +172,8 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	meter:            genericAdapter,
 	dcMeter:          genericAdapter,
 	waveform:         genericAdapter,
+	analyser:         genericAdapter,
+	follower:         genericAdapter,
 	signal:           genericAdapter,
 	scale:            genericAdapter,
 	scaleExp:         genericAdapter,

--- a/src/audio/audioCore.ts
+++ b/src/audio/audioCore.ts
@@ -195,6 +195,7 @@ const ROUTING: Record<AudioNodeEntry['kind'], PortAdapter> = {
 	waveform:         genericAdapter,
 	analyser:         genericAdapter,
 	follower:         genericAdapter,
+	recorder:         genericAdapter,
 	signal:           genericAdapter,
 	scale:            genericAdapter,
 	scaleExp:         genericAdapter,

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -171,3 +171,4 @@ export { getFFTValue }     from './nodes/fft';
 export { getMeterValue }   from './nodes/meter';
 export { getDCMeterValue } from './nodes/dcMeter';
 export { getWaveformValue } from './nodes/waveform';
+export { getAnalyserValue } from './nodes/analyser';

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -173,3 +173,7 @@ export { getDCMeterValue } from './nodes/dcMeter';
 export { getWaveformValue } from './nodes/waveform';
 export { getAnalyserValue } from './nodes/analyser';
 export { setSoloed } from './nodes/solo';
+
+export {
+	isRecorderSupported, startRecordingNode, pauseRecordingNode, stopRecordingNode, getRecorderState,
+} from './nodes/recorder';

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -172,3 +172,4 @@ export { getMeterValue }   from './nodes/meter';
 export { getDCMeterValue } from './nodes/dcMeter';
 export { getWaveformValue } from './nodes/waveform';
 export { getAnalyserValue } from './nodes/analyser';
+export { setSoloed } from './nodes/solo';

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -62,6 +62,7 @@ import { soloHandler }             from './nodes/solo';
 import { crossFadeHandler }        from './nodes/crossFade';
 import { pannerHandler }           from './nodes/panner';
 import { midSideCompressorHandler } from './nodes/midSideCompressor';
+import { multibandCompressorHandler } from './nodes/multibandCompressor';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -152,3 +153,4 @@ nodeRegistry.register('solo',             soloHandler);
 nodeRegistry.register('crossFade',        crossFadeHandler);
 nodeRegistry.register('panner',           pannerHandler);
 nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
+nodeRegistry.register('multibandCompressor', multibandCompressorHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -52,6 +52,12 @@ import { absHandler }              from './nodes/abs';
 import { negateHandler }           from './nodes/negate';
 import { audioToGainHandler }      from './nodes/audioToGain';
 import { gainToAudioHandler }      from './nodes/gainToAudio';
+import { compressorHandler }       from './nodes/compressor';
+import { filterHandler }           from './nodes/filter';
+import { eq3Handler }              from './nodes/eq3';
+import { multibandSplitHandler }   from './nodes/multibandSplit';
+import { analyserHandler }         from './nodes/analyser';
+import { followerHandler }         from './nodes/follower';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -132,3 +138,9 @@ nodeRegistry.register('abs',              absHandler);
 nodeRegistry.register('negate',           negateHandler);
 nodeRegistry.register('audioToGain',      audioToGainHandler);
 nodeRegistry.register('gainToAudio',      gainToAudioHandler);
+nodeRegistry.register('compressor',       compressorHandler);
+nodeRegistry.register('filter',           filterHandler);
+nodeRegistry.register('eq3',              eq3Handler);
+nodeRegistry.register('multibandSplit',   multibandSplitHandler);
+nodeRegistry.register('analyser',         analyserHandler);
+nodeRegistry.register('follower',         followerHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -63,6 +63,7 @@ import { crossFadeHandler }        from './nodes/crossFade';
 import { pannerHandler }           from './nodes/panner';
 import { midSideCompressorHandler } from './nodes/midSideCompressor';
 import { multibandCompressorHandler } from './nodes/multibandCompressor';
+import { panner3dHandler } from './nodes/panner3d';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -154,3 +155,4 @@ nodeRegistry.register('crossFade',        crossFadeHandler);
 nodeRegistry.register('panner',           pannerHandler);
 nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
 nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
+nodeRegistry.register('panner3d', panner3dHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -59,6 +59,8 @@ import { multibandSplitHandler }   from './nodes/multibandSplit';
 import { analyserHandler }         from './nodes/analyser';
 import { followerHandler }         from './nodes/follower';
 import { soloHandler }             from './nodes/solo';
+import { crossFadeHandler }        from './nodes/crossFade';
+import { pannerHandler }           from './nodes/panner';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -146,3 +148,5 @@ nodeRegistry.register('multibandSplit',   multibandSplitHandler);
 nodeRegistry.register('analyser',         analyserHandler);
 nodeRegistry.register('follower',         followerHandler);
 nodeRegistry.register('solo',             soloHandler);
+nodeRegistry.register('crossFade',        crossFadeHandler);
+nodeRegistry.register('panner',           pannerHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -61,6 +61,7 @@ import { followerHandler }         from './nodes/follower';
 import { soloHandler }             from './nodes/solo';
 import { crossFadeHandler }        from './nodes/crossFade';
 import { pannerHandler }           from './nodes/panner';
+import { midSideCompressorHandler } from './nodes/midSideCompressor';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -150,3 +151,4 @@ nodeRegistry.register('follower',         followerHandler);
 nodeRegistry.register('solo',             soloHandler);
 nodeRegistry.register('crossFade',        crossFadeHandler);
 nodeRegistry.register('panner',           pannerHandler);
+nodeRegistry.register('midSideCompressor', midSideCompressorHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -66,6 +66,7 @@ import { multibandCompressorHandler } from './nodes/multibandCompressor';
 import { panner3dHandler } from './nodes/panner3d';
 import { waveShaperHandler } from './nodes/waveShaper';
 import { recorderHandler } from './nodes/recorder';
+import { channelHandler } from './nodes/channel';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -160,3 +161,4 @@ nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
 nodeRegistry.register('panner3d', panner3dHandler);
 nodeRegistry.register('waveShaper', waveShaperHandler);
 nodeRegistry.register('recorder', recorderHandler);
+nodeRegistry.register('channel', channelHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -58,6 +58,7 @@ import { eq3Handler }              from './nodes/eq3';
 import { multibandSplitHandler }   from './nodes/multibandSplit';
 import { analyserHandler }         from './nodes/analyser';
 import { followerHandler }         from './nodes/follower';
+import { soloHandler }             from './nodes/solo';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -144,3 +145,4 @@ nodeRegistry.register('eq3',              eq3Handler);
 nodeRegistry.register('multibandSplit',   multibandSplitHandler);
 nodeRegistry.register('analyser',         analyserHandler);
 nodeRegistry.register('follower',         followerHandler);
+nodeRegistry.register('solo',             soloHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -65,6 +65,7 @@ import { midSideCompressorHandler } from './nodes/midSideCompressor';
 import { multibandCompressorHandler } from './nodes/multibandCompressor';
 import { panner3dHandler } from './nodes/panner3d';
 import { waveShaperHandler } from './nodes/waveShaper';
+import { recorderHandler } from './nodes/recorder';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -158,3 +159,4 @@ nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
 nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
 nodeRegistry.register('panner3d', panner3dHandler);
 nodeRegistry.register('waveShaper', waveShaperHandler);
+nodeRegistry.register('recorder', recorderHandler);

--- a/src/audio/nodeRegistry.ts
+++ b/src/audio/nodeRegistry.ts
@@ -64,6 +64,7 @@ import { pannerHandler }           from './nodes/panner';
 import { midSideCompressorHandler } from './nodes/midSideCompressor';
 import { multibandCompressorHandler } from './nodes/multibandCompressor';
 import { panner3dHandler } from './nodes/panner3d';
+import { waveShaperHandler } from './nodes/waveShaper';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const _registry = new Map<string, NodeTypeHandler<any>>();
@@ -156,3 +157,4 @@ nodeRegistry.register('panner',           pannerHandler);
 nodeRegistry.register('midSideCompressor', midSideCompressorHandler);
 nodeRegistry.register('multibandCompressor', multibandCompressorHandler);
 nodeRegistry.register('panner3d', panner3dHandler);
+nodeRegistry.register('waveShaper', waveShaperHandler);

--- a/src/audio/nodes/analyser.ts
+++ b/src/audio/nodes/analyser.ts
@@ -1,0 +1,42 @@
+import { Analyser } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { AnalyserNodeData } from '../../store/dawTypes';
+
+function getEntry(id: string) {
+	const e = _audioNodes.get(id);
+	return e?.kind === 'analyser' ? e : undefined;
+}
+
+export const analyserHandler: NodeTypeHandler<AnalyserNodeData> = {
+	defaultData: { label: 'Analyser', size: 1024, type: 'fft', smoothing: 0.8 },
+
+	create(id, data) {
+		const toneNode = new Analyser(data.type, data.size);
+		toneNode.smoothing = data.smoothing;
+		_audioNodes.set(id, { kind: 'analyser', toneNode });
+	},
+
+	dispose(id) {
+		const e = getEntry(id);
+		if (!e) return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = getEntry(id);
+		if (!e) return;
+		if (update.size      !== undefined) e.toneNode.size      = update.size;
+		if (update.type      !== undefined) e.toneNode.type      = update.type;
+		if (update.smoothing !== undefined) e.toneNode.smoothing = update.smoothing;
+	},
+};
+
+/** Live-polled readout — FFT bins or waveform samples depending on `type`. Single channel, so always a plain Float32Array. */
+export function getAnalyserValue(id: string): Float32Array | null {
+	const e = getEntry(id);
+	if (!e) return null;
+	const v = e.toneNode.getValue();
+	return Array.isArray(v) ? (v[0] ?? null) : v;
+}

--- a/src/audio/nodes/channel.ts
+++ b/src/audio/nodes/channel.ts
@@ -1,0 +1,33 @@
+import { Channel } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { ChannelNodeData } from '../../store/dawTypes';
+
+// Solo state is NOT threaded through here — Channel and Solo share Tone's own
+// static solo registry, and which instance is soloed is store-driven (daw.ts's
+// soloedNodeId, ADR-0003), set via setSoloed() in solo.ts, not through
+// setAudioParam. See ChannelNodeData's comment in dawTypes.ts.
+
+export const channelHandler: NodeTypeHandler<ChannelNodeData> = {
+	defaultData: { label: 'Channel', volume: 0, pan: 0, mute: false },
+
+	create(id, data) {
+		const toneNode = new Channel({ volume: data.volume, pan: data.pan, mute: data.mute });
+		_audioNodes.set(id, { kind: 'channel', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'channel') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'channel') return;
+		if (update.volume !== undefined) e.toneNode.volume.value = update.volume;
+		if (update.pan    !== undefined) e.toneNode.pan.value    = update.pan;
+		if (update.mute   !== undefined) e.toneNode.mute          = update.mute;
+	},
+};

--- a/src/audio/nodes/compressor.ts
+++ b/src/audio/nodes/compressor.ts
@@ -1,0 +1,36 @@
+import { Compressor } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { CompressorNodeData } from '../../store/dawTypes';
+
+export const compressorHandler: NodeTypeHandler<CompressorNodeData> = {
+	defaultData: { label: 'Compressor', threshold: -24, ratio: 12, attack: 0.003, release: 0.25, knee: 30 },
+
+	create(id, data) {
+		const toneNode = new Compressor({
+			threshold: data.threshold,
+			ratio:     data.ratio,
+			attack:    data.attack,
+			release:   data.release,
+			knee:      data.knee,
+		});
+		_audioNodes.set(id, { kind: 'compressor', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'compressor') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'compressor') return;
+		if (update.threshold !== undefined) e.toneNode.threshold.value = update.threshold;
+		if (update.ratio     !== undefined) e.toneNode.ratio.value     = update.ratio;
+		if (update.attack    !== undefined) e.toneNode.attack.value    = update.attack;
+		if (update.release   !== undefined) e.toneNode.release.value   = update.release;
+		if (update.knee      !== undefined) e.toneNode.knee.value      = update.knee;
+	},
+};

--- a/src/audio/nodes/compressor.ts
+++ b/src/audio/nodes/compressor.ts
@@ -1,7 +1,16 @@
 import { Compressor } from 'tone';
 import { _audioNodes } from '../audioCore';
 import type { NodeTypeHandler } from './nodeHandler';
-import type { CompressorNodeData } from '../../store/dawTypes';
+import type { CompressorNodeData, CompressorBandData } from '../../store/dawTypes';
+
+/** Applies a partial band update to a real Compressor instance — shared with MidSideCompressor/MultibandCompressor, whose `mid`/`side`/`low`/`high` bands are each a full Compressor instance too. */
+export function applyCompressorBand(node: Compressor, update: Partial<CompressorBandData>): void {
+	if (update.threshold !== undefined) node.threshold.value = update.threshold;
+	if (update.ratio     !== undefined) node.ratio.value     = update.ratio;
+	if (update.attack    !== undefined) node.attack.value    = update.attack;
+	if (update.release   !== undefined) node.release.value   = update.release;
+	if (update.knee      !== undefined) node.knee.value      = update.knee;
+}
 
 export const compressorHandler: NodeTypeHandler<CompressorNodeData> = {
 	defaultData: { label: 'Compressor', threshold: -24, ratio: 12, attack: 0.003, release: 0.25, knee: 30 },
@@ -27,10 +36,6 @@ export const compressorHandler: NodeTypeHandler<CompressorNodeData> = {
 	setAudioParam(id, update) {
 		const e = _audioNodes.get(id);
 		if (e?.kind !== 'compressor') return;
-		if (update.threshold !== undefined) e.toneNode.threshold.value = update.threshold;
-		if (update.ratio     !== undefined) e.toneNode.ratio.value     = update.ratio;
-		if (update.attack    !== undefined) e.toneNode.attack.value    = update.attack;
-		if (update.release   !== undefined) e.toneNode.release.value   = update.release;
-		if (update.knee      !== undefined) e.toneNode.knee.value      = update.knee;
+		applyCompressorBand(e.toneNode, update);
 	},
 };

--- a/src/audio/nodes/crossFade.ts
+++ b/src/audio/nodes/crossFade.ts
@@ -1,0 +1,26 @@
+import { CrossFade } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { CrossFadeNodeData } from '../../store/dawTypes';
+
+export const crossFadeHandler: NodeTypeHandler<CrossFadeNodeData> = {
+	defaultData: { label: 'CrossFade', fade: 0.5 },
+
+	create(id, data) {
+		const toneNode = new CrossFade(data.fade);
+		_audioNodes.set(id, { kind: 'crossFade', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'crossFade') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'crossFade') return;
+		if (update.fade !== undefined) e.toneNode.fade.value = update.fade;
+	},
+};

--- a/src/audio/nodes/eq3.ts
+++ b/src/audio/nodes/eq3.ts
@@ -1,0 +1,36 @@
+import { EQ3 } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { EQ3NodeData } from '../../store/dawTypes';
+
+export const eq3Handler: NodeTypeHandler<EQ3NodeData> = {
+	defaultData: { label: 'EQ3', low: 0, mid: 0, high: 0, lowFrequency: 400, highFrequency: 2500 },
+
+	create(id, data) {
+		const toneNode = new EQ3({
+			low:           data.low,
+			mid:           data.mid,
+			high:          data.high,
+			lowFrequency:  data.lowFrequency,
+			highFrequency: data.highFrequency,
+		});
+		_audioNodes.set(id, { kind: 'eq3', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'eq3') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'eq3') return;
+		if (update.low           !== undefined) e.toneNode.low.value           = update.low;
+		if (update.mid           !== undefined) e.toneNode.mid.value           = update.mid;
+		if (update.high          !== undefined) e.toneNode.high.value          = update.high;
+		if (update.lowFrequency  !== undefined) e.toneNode.lowFrequency.value  = update.lowFrequency;
+		if (update.highFrequency !== undefined) e.toneNode.highFrequency.value = update.highFrequency;
+	},
+};

--- a/src/audio/nodes/filter.ts
+++ b/src/audio/nodes/filter.ts
@@ -1,0 +1,38 @@
+import { Filter } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { FilterNodeData } from '../../store/dawTypes';
+
+export const filterHandler: NodeTypeHandler<FilterNodeData> = {
+	defaultData: { label: 'Filter', frequency: 350, type: 'lowpass', rolloff: -12, Q: 1, detune: 0, gain: 0 },
+
+	create(id, data) {
+		const toneNode = new Filter({
+			frequency: data.frequency,
+			type:      data.type,
+			rolloff:   data.rolloff,
+			Q:         data.Q,
+			detune:    data.detune,
+			gain:      data.gain,
+		});
+		_audioNodes.set(id, { kind: 'filter', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'filter') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'filter') return;
+		if (update.frequency !== undefined) e.toneNode.frequency.value = update.frequency;
+		if (update.detune    !== undefined) e.toneNode.detune.value    = update.detune;
+		if (update.Q         !== undefined) e.toneNode.Q.value         = update.Q;
+		if (update.gain      !== undefined) e.toneNode.gain.value      = update.gain;
+		if (update.type      !== undefined) e.toneNode.type            = update.type;
+		if (update.rolloff   !== undefined) e.toneNode.rolloff         = update.rolloff;
+	},
+};

--- a/src/audio/nodes/follower.ts
+++ b/src/audio/nodes/follower.ts
@@ -1,0 +1,26 @@
+import { Follower } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { FollowerNodeData } from '../../store/dawTypes';
+
+export const followerHandler: NodeTypeHandler<FollowerNodeData> = {
+	defaultData: { label: 'Follower', smoothing: 0.05 },
+
+	create(id, data) {
+		const toneNode = new Follower(data.smoothing);
+		_audioNodes.set(id, { kind: 'follower', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'follower') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'follower') return;
+		if (update.smoothing !== undefined) e.toneNode.smoothing = update.smoothing;
+	},
+};

--- a/src/audio/nodes/midSideCompressor.ts
+++ b/src/audio/nodes/midSideCompressor.ts
@@ -1,0 +1,31 @@
+import { MidSideCompressor } from 'tone';
+import { _audioNodes } from '../audioCore';
+import { applyCompressorBand } from './compressor';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { MidSideCompressorNodeData } from '../../store/dawTypes';
+
+const DEFAULT_MID  = { threshold: -24, ratio: 3, attack: 0.02, release: 0.03, knee: 16 };
+const DEFAULT_SIDE = { threshold: -30, ratio: 6, attack: 0.03, release: 0.25, knee: 10 };
+
+export const midSideCompressorHandler: NodeTypeHandler<MidSideCompressorNodeData> = {
+	defaultData: { label: 'MidSideCompressor', mid: DEFAULT_MID, side: DEFAULT_SIDE },
+
+	create(id, data) {
+		const toneNode = new MidSideCompressor({ mid: data.mid, side: data.side });
+		_audioNodes.set(id, { kind: 'midSideCompressor', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'midSideCompressor') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'midSideCompressor') return;
+		if (update.mid)  applyCompressorBand(e.toneNode.mid,  update.mid);
+		if (update.side) applyCompressorBand(e.toneNode.side, update.side);
+	},
+};

--- a/src/audio/nodes/multibandCompressor.ts
+++ b/src/audio/nodes/multibandCompressor.ts
@@ -1,0 +1,46 @@
+import { MultibandCompressor } from 'tone';
+import { _audioNodes } from '../audioCore';
+import { applyCompressorBand } from './compressor';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { MultibandCompressorNodeData } from '../../store/dawTypes';
+
+const DEFAULT_BAND = { threshold: -24, ratio: 12, attack: 0.003, release: 0.25, knee: 30 };
+
+export const multibandCompressorHandler: NodeTypeHandler<MultibandCompressorNodeData> = {
+	defaultData: {
+		label:         'MultibandCompressor',
+		lowFrequency:  250,
+		highFrequency: 2000,
+		low:           DEFAULT_BAND,
+		mid:           DEFAULT_BAND,
+		high:          DEFAULT_BAND,
+	},
+
+	create(id, data) {
+		const toneNode = new MultibandCompressor({
+			lowFrequency:  data.lowFrequency,
+			highFrequency: data.highFrequency,
+			low:           data.low,
+			mid:           data.mid,
+			high:          data.high,
+		});
+		_audioNodes.set(id, { kind: 'multibandCompressor', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandCompressor') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandCompressor') return;
+		if (update.lowFrequency  !== undefined) e.toneNode.lowFrequency.value  = update.lowFrequency;
+		if (update.highFrequency !== undefined) e.toneNode.highFrequency.value = update.highFrequency;
+		if (update.low)  applyCompressorBand(e.toneNode.low,  update.low);
+		if (update.mid)  applyCompressorBand(e.toneNode.mid,  update.mid);
+		if (update.high) applyCompressorBand(e.toneNode.high, update.high);
+	},
+};

--- a/src/audio/nodes/multibandSplit.ts
+++ b/src/audio/nodes/multibandSplit.ts
@@ -1,0 +1,32 @@
+import { MultibandSplit } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { MultibandSplitNodeData } from '../../store/dawTypes';
+
+export const multibandSplitHandler: NodeTypeHandler<MultibandSplitNodeData> = {
+	defaultData: { label: 'MultibandSplit', lowFrequency: 400, highFrequency: 2500, Q: 1 },
+
+	create(id, data) {
+		const toneNode = new MultibandSplit({
+			lowFrequency:  data.lowFrequency,
+			highFrequency: data.highFrequency,
+			Q:             data.Q,
+		});
+		_audioNodes.set(id, { kind: 'multibandSplit', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandSplit') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'multibandSplit') return;
+		if (update.lowFrequency  !== undefined) e.toneNode.lowFrequency.value  = update.lowFrequency;
+		if (update.highFrequency !== undefined) e.toneNode.highFrequency.value = update.highFrequency;
+		if (update.Q             !== undefined) e.toneNode.Q.value             = update.Q;
+	},
+};

--- a/src/audio/nodes/panner.ts
+++ b/src/audio/nodes/panner.ts
@@ -1,0 +1,33 @@
+import { Panner, Split } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { PannerNodeData } from '../../store/dawTypes';
+
+// Panner wraps a single stereo StereoPannerNode with no native separate L/R
+// taps — out-0/out-1 are satisfied by an internal Split(2), same shape as
+// player.ts's/grainPlayer.ts's split field.
+
+export const pannerHandler: NodeTypeHandler<PannerNodeData> = {
+	defaultData: { label: 'Panner', pan: 0 },
+
+	create(id, data) {
+		const toneNode = new Panner(data.pan);
+		const split    = new Split(2);
+		toneNode.connect(split);
+		_audioNodes.set(id, { kind: 'panner', toneNode, split });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner') return;
+		e.toneNode.dispose();
+		e.split.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner') return;
+		if (update.pan !== undefined) e.toneNode.pan.value = update.pan;
+	},
+};

--- a/src/audio/nodes/panner3d.ts
+++ b/src/audio/nodes/panner3d.ts
@@ -1,0 +1,34 @@
+import { Panner3D } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { Panner3DNodeData } from '../../store/dawTypes';
+
+export const panner3dHandler: NodeTypeHandler<Panner3DNodeData> = {
+	defaultData: { label: 'Panner3D', positionX: 0, positionY: 0, positionZ: 0, panningModel: 'equalpower' },
+
+	create(id, data) {
+		const toneNode = new Panner3D({
+			positionX:    data.positionX,
+			positionY:    data.positionY,
+			positionZ:    data.positionZ,
+			panningModel: data.panningModel,
+		});
+		_audioNodes.set(id, { kind: 'panner3d', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner3d') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'panner3d') return;
+		if (update.positionX    !== undefined) e.toneNode.positionX.value = update.positionX;
+		if (update.positionY    !== undefined) e.toneNode.positionY.value = update.positionY;
+		if (update.positionZ    !== undefined) e.toneNode.positionZ.value = update.positionZ;
+		if (update.panningModel !== undefined) e.toneNode.panningModel    = update.panningModel;
+	},
+};

--- a/src/audio/nodes/recorder.ts
+++ b/src/audio/nodes/recorder.ts
@@ -46,7 +46,16 @@ export async function startRecordingNode(id: string): Promise<void> {
 	const entry = getEntry(id);
 	if (!entry) return;
 	await toneStart();
-	await entry.toneNode.start();
+	// The underlying MediaRecorder's `start` event only fires once audio data
+	// actually begins flowing through the stream -- an idle Recorder (nothing
+	// wired in yet, or a silent/unstarted source) never gets it, which would
+	// hang this forever even though the native recorder's .state already
+	// flips to "started" synchronously. Race a short timeout so the UI never
+	// gets stuck waiting on an event that may never arrive.
+	await Promise.race([
+		entry.toneNode.start().catch(() => {}),
+		new Promise<void>(resolve => setTimeout(resolve, 200)),
+	]);
 }
 
 export function pauseRecordingNode(id: string): void {

--- a/src/audio/nodes/recorder.ts
+++ b/src/audio/nodes/recorder.ts
@@ -1,0 +1,67 @@
+import { Recorder, start as toneStart } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { RecorderNodeData, RecorderAudioEntry } from '../../store/dawTypes';
+
+// ─── Recorder node ────────────────────────────────────────────────────────────
+// No live params (docs/adr/0006-recorder-v1-interaction-scope.md): mimeType is
+// constructor-only on Tone's Recorder, so v1 skips it entirely rather than
+// rebuilding the toneNode on every change. Sink topology — in-0 only, no
+// output. Own start/pause/stop lifecycle functions below, called directly by
+// the node's UI, mirroring player.ts's playNode/pauseNode/seekNode precedent
+// rather than threading record/pause/stop-with-blob through the shared
+// NodeTypeHandler.start/stop protocol (reserved for single-use-source restart).
+
+function getEntry(id: string): RecorderAudioEntry | undefined {
+	const e = _audioNodes.get(id);
+	return e?.kind === 'recorder' ? e : undefined;
+}
+
+export const recorderHandler: NodeTypeHandler<RecorderNodeData> = {
+	defaultData: { label: 'Recorder' },
+
+	create(id) {
+		const toneNode = new Recorder();
+		_audioNodes.set(id, { kind: 'recorder', toneNode });
+	},
+
+	dispose(id) {
+		const entry = getEntry(id);
+		if (!entry) return;
+		if (entry.toneNode.state === 'started') entry.toneNode.stop().catch(() => {});
+		entry.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam() { /* no live params — see ADR-0006 */ },
+};
+
+// ─── Recording operations ──────────────────────────────────────────────────────
+
+export function isRecorderSupported(): boolean {
+	return Recorder.supported;
+}
+
+export async function startRecordingNode(id: string): Promise<void> {
+	const entry = getEntry(id);
+	if (!entry) return;
+	await toneStart();
+	await entry.toneNode.start();
+}
+
+export function pauseRecordingNode(id: string): void {
+	const entry = getEntry(id);
+	if (!entry) return;
+	entry.toneNode.pause();
+}
+
+export async function stopRecordingNode(id: string): Promise<Blob | null> {
+	const entry = getEntry(id);
+	if (!entry) return null;
+	return entry.toneNode.stop();
+}
+
+export function getRecorderState(id: string): 'started' | 'stopped' | 'paused' {
+	const entry = getEntry(id);
+	return entry?.toneNode.state ?? 'stopped';
+}

--- a/src/audio/nodes/solo.ts
+++ b/src/audio/nodes/solo.ts
@@ -1,0 +1,35 @@
+import { Solo } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { SoloNodeData } from '../../store/dawTypes';
+
+// Solo has no configurable params exposed through the generic setNodeParam
+// path — which instance is soloed is store-driven (daw.ts's soloedNodeId,
+// ADR-0003), set via setSoloed() below, not through NodeTypeHandler.
+
+export const soloHandler: NodeTypeHandler<SoloNodeData> = {
+	defaultData: { label: 'Solo' },
+
+	create(id) {
+		const toneNode = new Solo();
+		_audioNodes.set(id, { kind: 'solo', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'solo') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam() {
+		// No configurable params — see setSoloed().
+	},
+};
+
+/** Solos or unsolos this instance. Tone's own static registry mutes every other Solo/Channel instance in the context. */
+export function setSoloed(id: string, soloed: boolean): void {
+	const e = _audioNodes.get(id);
+	if (e?.kind !== 'solo') return;
+	e.toneNode.solo = soloed;
+}

--- a/src/audio/nodes/solo.ts
+++ b/src/audio/nodes/solo.ts
@@ -5,7 +5,10 @@ import type { SoloNodeData } from '../../store/dawTypes';
 
 // Solo has no configurable params exposed through the generic setNodeParam
 // path — which instance is soloed is store-driven (daw.ts's soloedNodeId,
-// ADR-0003), set via setSoloed() below, not through NodeTypeHandler.
+// ADR-0003), set via setSoloed() below, not through NodeTypeHandler. Channel
+// (src/audio/nodes/channel.ts) shares Tone's own static solo registry with
+// Solo, so setSoloed() below handles both entry kinds rather than duplicating
+// this function there.
 
 export const soloHandler: NodeTypeHandler<SoloNodeData> = {
 	defaultData: { label: 'Solo' },
@@ -30,6 +33,6 @@ export const soloHandler: NodeTypeHandler<SoloNodeData> = {
 /** Solos or unsolos this instance. Tone's own static registry mutes every other Solo/Channel instance in the context. */
 export function setSoloed(id: string, soloed: boolean): void {
 	const e = _audioNodes.get(id);
-	if (e?.kind !== 'solo') return;
+	if (e?.kind !== 'solo' && e?.kind !== 'channel') return;
 	e.toneNode.solo = soloed;
 }

--- a/src/audio/nodes/stub.ts
+++ b/src/audio/nodes/stub.ts
@@ -2,7 +2,7 @@ import type { NodeTypeHandler } from './nodeHandler';
 import type { StubNodeData } from '../../store/dawTypes';
 
 export const stubHandler: NodeTypeHandler<StubNodeData> = {
-	defaultData: { label: 'Stub', kind: 'filter' },
+	defaultData: { label: 'Stub', kind: 'panner' },
 	create()        { /* not yet implemented */ },
 	dispose()       { /* not yet implemented */ },
 	setAudioParam() { /* not yet implemented */ },

--- a/src/audio/nodes/stub.ts
+++ b/src/audio/nodes/stub.ts
@@ -2,7 +2,7 @@ import type { NodeTypeHandler } from './nodeHandler';
 import type { StubNodeData } from '../../store/dawTypes';
 
 export const stubHandler: NodeTypeHandler<StubNodeData> = {
-	defaultData: { label: 'Stub', kind: 'channel' },
+	defaultData: { label: 'Stub', kind: 'convolver' },
 	create()        { /* not yet implemented */ },
 	dispose()       { /* not yet implemented */ },
 	setAudioParam() { /* not yet implemented */ },

--- a/src/audio/nodes/stub.ts
+++ b/src/audio/nodes/stub.ts
@@ -2,7 +2,7 @@ import type { NodeTypeHandler } from './nodeHandler';
 import type { StubNodeData } from '../../store/dawTypes';
 
 export const stubHandler: NodeTypeHandler<StubNodeData> = {
-	defaultData: { label: 'Stub', kind: 'panner' },
+	defaultData: { label: 'Stub', kind: 'channel' },
 	create()        { /* not yet implemented */ },
 	dispose()       { /* not yet implemented */ },
 	setAudioParam() { /* not yet implemented */ },

--- a/src/audio/nodes/waveShaper.ts
+++ b/src/audio/nodes/waveShaper.ts
@@ -1,0 +1,35 @@
+import { WaveShaper } from 'tone';
+import { _audioNodes } from '../audioCore';
+import type { NodeTypeHandler } from './nodeHandler';
+import type { WaveShaperNodeData, WaveShaperPreset } from '../../store/dawTypes';
+
+// Named curves standing in for a real curve editor (docs/adr/0005-waveshaper-preset-driven.md).
+const PRESET_MAPPINGS: Record<WaveShaperPreset, (value: number) => number> = {
+	identity: value => value,
+	softClip: value => Math.tanh(value * 2),
+	hardClip: value => Math.max(-1, Math.min(1, value * 3)),
+};
+
+export const waveShaperHandler: NodeTypeHandler<WaveShaperNodeData> = {
+	defaultData: { label: 'WaveShaper', preset: 'identity', oversample: 'none' },
+
+	create(id, data) {
+		const toneNode = new WaveShaper(PRESET_MAPPINGS[data.preset], 1024);
+		toneNode.oversample = data.oversample;
+		_audioNodes.set(id, { kind: 'waveShaper', toneNode });
+	},
+
+	dispose(id) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'waveShaper') return;
+		e.toneNode.dispose();
+		_audioNodes.delete(id);
+	},
+
+	setAudioParam(id, update) {
+		const e = _audioNodes.get(id);
+		if (e?.kind !== 'waveShaper') return;
+		if (update.preset     !== undefined) e.toneNode.setMap(PRESET_MAPPINGS[update.preset]);
+		if (update.oversample !== undefined) e.toneNode.oversample = update.oversample;
+	},
+};

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -97,6 +97,7 @@ import { MergeNode }              from './nodes/processing/MergeNode';
 import { MonoNode }               from './nodes/processing/MonoNode';
 import { VolumeNode }             from './nodes/processing/VolumeNode';
 import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
+import { SoloNode }               from './nodes/processing/SoloNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
@@ -166,6 +167,7 @@ const nodeTypes = {
 	mono:             MonoNode,
 	volume:           VolumeNode,
 	multibandSplit:   MultibandSplitNode,
+	solo:             SoloNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -98,6 +98,8 @@ import { MonoNode }               from './nodes/processing/MonoNode';
 import { VolumeNode }             from './nodes/processing/VolumeNode';
 import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
 import { SoloNode }               from './nodes/processing/SoloNode';
+import { CrossFadeNode }          from './nodes/processing/CrossFadeNode';
+import { PannerNode }             from './nodes/processing/PannerNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
@@ -168,6 +170,8 @@ const nodeTypes = {
 	volume:           VolumeNode,
 	multibandSplit:   MultibandSplitNode,
 	solo:             SoloNode,
+	crossFade:        CrossFadeNode,
+	panner:           PannerNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -116,6 +116,7 @@ import { AbsNode }                from './nodes/signal/AbsNode';
 import { NegateNode }             from './nodes/signal/NegateNode';
 import { AudioToGainNode }        from './nodes/signal/AudioToGainNode';
 import { GainToAudioNode }        from './nodes/signal/GainToAudioNode';
+import { WaveShaperNode }         from './nodes/signal/WaveShaperNode';
 import { DeletableEdge }    from './edges/DeletableEdge';
 import { AddNodePanel }     from './panels/AddNodePanel';
 import { PatchPanel }      from './panels/PatchPanel';
@@ -191,6 +192,7 @@ const nodeTypes = {
 	negate:           NegateNode,
 	audioToGain:      AudioToGainNode,
 	gainToAudio:      GainToAudioNode,
+	waveShaper:       WaveShaperNode,
 };
 
 const edgeTypes = {

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -87,16 +87,22 @@ import { AutoPannerNode }         from './nodes/effects/AutoPannerNode';
 import { AutoWahNode }            from './nodes/effects/AutoWahNode';
 import { LimiterNode }            from './nodes/dynamics/LimiterNode';
 import { GateNode }               from './nodes/dynamics/GateNode';
+import { CompressorNode }         from './nodes/dynamics/CompressorNode';
 import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
+import { FilterNode }             from './nodes/processing/FilterNode';
+import { EQ3Node }                from './nodes/processing/EQ3Node';
 import { PanVolNode }             from './nodes/processing/PanVolNode';
 import { SplitNode }              from './nodes/processing/SplitNode';
 import { MergeNode }              from './nodes/processing/MergeNode';
 import { MonoNode }               from './nodes/processing/MonoNode';
 import { VolumeNode }             from './nodes/processing/VolumeNode';
+import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
 import { WaveformNode }           from './nodes/analysis/WaveformNode';
+import { AnalyserNode }           from './nodes/analysis/AnalyserNode';
+import { FollowerNode }           from './nodes/analysis/FollowerNode';
 import { SignalNode }             from './nodes/signal/SignalNode';
 import { ScaleNode }              from './nodes/signal/ScaleNode';
 import { ScaleExpNode }           from './nodes/signal/ScaleExpNode';
@@ -150,16 +156,22 @@ const nodeTypes = {
 	autoWah:          AutoWahNode,
 	limiter:          LimiterNode,
 	gate:             GateNode,
+	compressor:       CompressorNode,
 	biquadFilter:     BiquadFilterNode,
+	filter:           FilterNode,
+	eq3:              EQ3Node,
 	panVol:           PanVolNode,
 	split:            SplitNode,
 	merge:            MergeNode,
 	mono:             MonoNode,
 	volume:           VolumeNode,
+	multibandSplit:   MultibandSplitNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,
 	waveform:         WaveformNode,
+	analyser:         AnalyserNode,
+	follower:         FollowerNode,
 	signal:           SignalNode,
 	scale:            ScaleNode,
 	scaleExp:         ScaleExpNode,

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -109,6 +109,7 @@ import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
 import { WaveformNode }           from './nodes/analysis/WaveformNode';
 import { AnalyserNode }           from './nodes/analysis/AnalyserNode';
 import { FollowerNode }           from './nodes/analysis/FollowerNode';
+import { RecorderNode }           from './nodes/analysis/RecorderNode';
 import { SignalNode }             from './nodes/signal/SignalNode';
 import { ScaleNode }              from './nodes/signal/ScaleNode';
 import { ScaleExpNode }           from './nodes/signal/ScaleExpNode';
@@ -185,6 +186,7 @@ const nodeTypes = {
 	waveform:         WaveformNode,
 	analyser:         AnalyserNode,
 	follower:         FollowerNode,
+	recorder:         RecorderNode,
 	signal:           SignalNode,
 	scale:            ScaleNode,
 	scaleExp:         ScaleExpNode,

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -94,6 +94,7 @@ import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
 import { FilterNode }             from './nodes/processing/FilterNode';
 import { EQ3Node }                from './nodes/processing/EQ3Node';
 import { PanVolNode }             from './nodes/processing/PanVolNode';
+import { ChannelNode }            from './nodes/processing/ChannelNode';
 import { SplitNode }              from './nodes/processing/SplitNode';
 import { MergeNode }              from './nodes/processing/MergeNode';
 import { MonoNode }               from './nodes/processing/MonoNode';
@@ -171,6 +172,7 @@ const nodeTypes = {
 	filter:           FilterNode,
 	eq3:              EQ3Node,
 	panVol:           PanVolNode,
+	channel:          ChannelNode,
 	split:            SplitNode,
 	merge:            MergeNode,
 	mono:             MonoNode,

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -9,7 +9,6 @@ import {
 	useReactFlow,
 	applyNodeChanges,
 	type NodeChange,
-	type Node,
 } from '@xyflow/react';
 import { useShallow } from 'zustand/react/shallow';
 import Box from '@mui/material/Box';
@@ -451,7 +450,7 @@ export function DawCanvas(layout: LayoutControls) {
 		isDragging.current = true;
 	}, []);
 
-	const handleNodeDragStop = useCallback((_event: React.MouseEvent, _node: Node, nodes: AppNode[]) => {
+	const handleNodeDragStop = useCallback((_event: MouseEvent | TouchEvent, _node: AppNode, nodes: AppNode[]) => {
 		isDragging.current = false;
 		// Wrap in startTransition so the Zustand flush is treated as a low-priority
 		// update. Without this, the synchronous React commit blocks the main thread

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -88,6 +88,7 @@ import { AutoWahNode }            from './nodes/effects/AutoWahNode';
 import { LimiterNode }            from './nodes/dynamics/LimiterNode';
 import { GateNode }               from './nodes/dynamics/GateNode';
 import { CompressorNode }         from './nodes/dynamics/CompressorNode';
+import { MidSideCompressorNode }  from './nodes/dynamics/MidSideCompressorNode';
 import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
 import { FilterNode }             from './nodes/processing/FilterNode';
 import { EQ3Node }                from './nodes/processing/EQ3Node';
@@ -160,6 +161,7 @@ const nodeTypes = {
 	limiter:          LimiterNode,
 	gate:             GateNode,
 	compressor:       CompressorNode,
+	midSideCompressor: MidSideCompressorNode,
 	biquadFilter:     BiquadFilterNode,
 	filter:           FilterNode,
 	eq3:              EQ3Node,

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -102,6 +102,7 @@ import { MultibandSplitNode }     from './nodes/processing/MultibandSplitNode';
 import { SoloNode }               from './nodes/processing/SoloNode';
 import { CrossFadeNode }          from './nodes/processing/CrossFadeNode';
 import { PannerNode }             from './nodes/processing/PannerNode';
+import { Panner3DNode }           from './nodes/processing/Panner3DNode';
 import { FFTNode }                from './nodes/analysis/FFTNode';
 import { MeterNode }              from './nodes/analysis/MeterNode';
 import { DCMeterNode }            from './nodes/analysis/DCMeterNode';
@@ -176,6 +177,7 @@ const nodeTypes = {
 	solo:             SoloNode,
 	crossFade:        CrossFadeNode,
 	panner:           PannerNode,
+	panner3d:         Panner3DNode,
 	fft:              FFTNode,
 	meter:            MeterNode,
 	dcMeter:          DCMeterNode,

--- a/src/daw/DawCanvas.tsx
+++ b/src/daw/DawCanvas.tsx
@@ -89,6 +89,7 @@ import { LimiterNode }            from './nodes/dynamics/LimiterNode';
 import { GateNode }               from './nodes/dynamics/GateNode';
 import { CompressorNode }         from './nodes/dynamics/CompressorNode';
 import { MidSideCompressorNode }  from './nodes/dynamics/MidSideCompressorNode';
+import { MultibandCompressorNode } from './nodes/dynamics/MultibandCompressorNode';
 import { BiquadFilterNode }       from './nodes/processing/BiquadFilterNode';
 import { FilterNode }             from './nodes/processing/FilterNode';
 import { EQ3Node }                from './nodes/processing/EQ3Node';
@@ -162,6 +163,7 @@ const nodeTypes = {
 	gate:             GateNode,
 	compressor:       CompressorNode,
 	midSideCompressor: MidSideCompressorNode,
+	multibandCompressor: MultibandCompressorNode,
 	biquadFilter:     BiquadFilterNode,
 	filter:           FilterNode,
 	eq3:              EQ3Node,

--- a/src/daw/nodes/analysis/AnalyserNode.tsx
+++ b/src/daw/nodes/analysis/AnalyserNode.tsx
@@ -4,23 +4,23 @@ import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import { useDawStore } from '../../../store/daw';
-import { getFFTValue } from '../../../audio/engine';
+import { getAnalyserValue } from '../../../audio/engine';
 import { NodeHeader } from '../shared/NodeHeader';
 import { NODE_COLORS } from '../shared/nodeColors';
 import { GRID_UNIT } from '../shared/gridSystem';
 import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx, HW_INSET } from '../shared/hwStyles';
-import { HwSwitch } from '../shared/hwComponents';
 import { useCanvasReadout } from '../shared/useCanvasReadout';
 import { HwArcSlider } from '../../../components/hw/HwArcSlider';
-import { ANALYSIS_SIZE_OPTIONS, type FFTFlowNode } from '../../../store/dawTypes';
+import { ANALYSIS_SIZE_OPTIONS, type AnalyserFlowNode, type AnalyserType } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.utility;
 const CANVAS_W = 176;
 const CANVAS_H = 48;
+const ANALYSER_TYPES: AnalyserType[] = ['fft', 'waveform'];
 
-export const FFTNode = memo(function FFTNode({ id, data, selected }: NodeProps<FFTFlowNode>) {
+export const AnalyserNode = memo(function AnalyserNode({ id, data, selected }: NodeProps<AnalyserFlowNode>) {
 	const setNodeParam = useDawStore(s => s.setNodeParam);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const sx = useMemo(() => ({
@@ -30,37 +30,57 @@ export const FFTNode = memo(function FFTNode({ id, data, selected }: NodeProps<F
 	}), []);
 
 	useCanvasReadout(canvasRef, CANVAS_W, CANVAS_H, ctx => {
-		const bins = getFFTValue(id);
-		if (!bins) return;
-		const lo = data.normalRange ? 0 : -100;
-		const hi = data.normalRange ? 1 : 0;
-		const barW = CANVAS_W / bins.length;
-		ctx.fillStyle = color;
-		for (let i = 0; i < bins.length; i++) {
-			const norm = Math.max(0, Math.min(1, (bins[i] - lo) / (hi - lo)));
-			const h = norm * CANVAS_H;
-			ctx.fillRect(i * barW, CANVAS_H - h, Math.max(1, barW - 1), h);
+		const values = getAnalyserValue(id);
+		if (!values) return;
+
+		if (data.type === 'waveform') {
+			ctx.strokeStyle = color;
+			ctx.lineWidth = 1;
+			ctx.beginPath();
+			const step = CANVAS_W / values.length;
+			for (let i = 0; i < values.length; i++) {
+				const x = i * step;
+				const y = (1 - (values[i] + 1) / 2) * CANVAS_H;
+				if (i === 0) ctx.moveTo(x, y);
+				else ctx.lineTo(x, y);
+			}
+			ctx.stroke();
+		} else {
+			const barW = CANVAS_W / values.length;
+			ctx.fillStyle = color;
+			for (let i = 0; i < values.length; i++) {
+				const norm = Math.max(0, Math.min(1, (values[i] + 100) / 100));
+				const h = norm * CANVAS_H;
+				ctx.fillRect(i * barW, CANVAS_H - h, Math.max(1, barW - 1), h);
+			}
 		}
 	});
 
 	return (
 		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
-			<NodeHeader id={id} label='FFT' selected={selected} accentColor={color} filledHeader />
+			<NodeHeader id={id} label='Analyser' selected={selected} accentColor={color} filledHeader />
 
 			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
 				<Box sx={{ ...HW_INSET, p: 0.5 }}>
 					<canvas ref={canvasRef} width={CANVAS_W} height={CANVAS_H} style={{ display: 'block', width: '100%', height: CANVAS_H }} />
 				</Box>
-				<Select value={data.size} onChange={e => setNodeParam(id, { size: Number(e.target.value) })} fullWidth
-					sx={sx.select} MenuProps={sx.selectMenu}>
-					{ANALYSIS_SIZE_OPTIONS.map(s => (
-						<MenuItem key={s} value={s} sx={sx.menuItem}>{s}</MenuItem>
-					))}
-				</Select>
+				<Box sx={{ display: 'flex', gap: 0.75 }}>
+					<Select value={data.type} onChange={e => setNodeParam(id, { type: e.target.value as AnalyserType })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{ANALYSER_TYPES.map(t => (
+							<MenuItem key={t} value={t} sx={sx.menuItem}>{t}</MenuItem>
+						))}
+					</Select>
+					<Select value={data.size} onChange={e => setNodeParam(id, { size: Number(e.target.value) })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{ANALYSIS_SIZE_OPTIONS.map(s => (
+							<MenuItem key={s} value={s} sx={sx.menuItem}>{s}</MenuItem>
+						))}
+					</Select>
+				</Box>
 				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
 					<HwArcSlider label='smoothing' value={data.smoothing} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { smoothing: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
 				</Box>
-				<HwSwitch checked={data.normalRange} color={color} onChange={() => setNodeParam(id, { normalRange: !data.normalRange })} label='normal range' />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/analysis/FollowerNode.tsx
+++ b/src/daw/nodes/analysis/FollowerNode.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { FollowerFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.utility;
+
+export const FollowerNode = memo(function FollowerNode({ id, data, selected }: NodeProps<FollowerFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Follower' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='smoothing' value={data.smoothing} min={0.001} max={1} step={0.001} color={color} onChange={v => setNodeParam(id, { smoothing: v })} format={v => v.toFixed(3)} unit='s' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/analysis/RecorderNode.tsx
+++ b/src/daw/nodes/analysis/RecorderNode.tsx
@@ -1,0 +1,145 @@
+import { memo, useEffect, useRef, useState } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import PauseIcon from '@mui/icons-material/Pause';
+import StopIcon from '@mui/icons-material/Stop';
+import DownloadIcon from '@mui/icons-material/Download';
+import {
+	isRecorderSupported, startRecordingNode, pauseRecordingNode, stopRecordingNode,
+} from '../../../audio/engine';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwIconBtn, hwIconBtnLit } from '../shared/hwStyles';
+import type { RecorderFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.utility;
+
+function formatDuration(seconds: number): string {
+	const m = Math.floor(seconds / 60);
+	const s = Math.floor(seconds % 60);
+	return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function formatSize(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Persistent Download button, not auto-download on stop — the user decides
+// when (or whether) the take leaves the browser (docs/adr/0006-recorder-v1-
+// interaction-scope.md). No live params either: mimeType is constructor-only
+// on Tone's Recorder, so this node has no editable data at all.
+export const RecorderNode = memo(function RecorderNode({ id, selected }: NodeProps<RecorderFlowNode>) {
+	const supported = isRecorderSupported();
+
+	const [state, setState]       = useState<'idle' | 'recording' | 'paused' | 'stopped'>('idle');
+	const [elapsed, setElapsed]   = useState(0);
+	const [blobUrl, setBlobUrl]   = useState<string | null>(null);
+	const [blobSize, setBlobSize] = useState(0);
+	const [finalDuration, setFinalDuration] = useState(0);
+
+	const startedAtRef = useRef(0);
+	const accumRef      = useRef(0);
+	const rafRef        = useRef(0);
+	const blobUrlRef    = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (state !== 'recording') return;
+		startedAtRef.current = performance.now();
+		const tick = () => {
+			setElapsed(accumRef.current + (performance.now() - startedAtRef.current) / 1000);
+			rafRef.current = requestAnimationFrame(tick);
+		};
+		rafRef.current = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(rafRef.current);
+	}, [state]);
+
+	useEffect(() => () => { if (blobUrlRef.current) URL.revokeObjectURL(blobUrlRef.current); }, []);
+
+	const handleRecord = async () => {
+		if (state === 'stopped' && blobUrlRef.current) {
+			URL.revokeObjectURL(blobUrlRef.current);
+			blobUrlRef.current = null;
+			setBlobUrl(null);
+			accumRef.current = 0;
+			setElapsed(0);
+		}
+		await startRecordingNode(id);
+		setState('recording');
+	};
+
+	const handlePause = () => {
+		accumRef.current = elapsed;
+		pauseRecordingNode(id);
+		setState('paused');
+	};
+
+	const handleStop = async () => {
+		if (state === 'recording') accumRef.current = elapsed;
+		const blob = await stopRecordingNode(id);
+		setFinalDuration(accumRef.current);
+		setState('stopped');
+		if (blob) {
+			const url = URL.createObjectURL(blob);
+			blobUrlRef.current = url;
+			setBlobUrl(url);
+			setBlobSize(blob.size);
+		}
+	};
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Recorder' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75, alignItems: 'center' }} className='nodrag'>
+				{!supported ? (
+					<Typography variant='caption' color='text.disabled' sx={{ fontSize: 9, textAlign: 'center' }}>
+						MediaRecorder not supported in this browser
+					</Typography>
+				) : (
+					<>
+						<Box sx={{ display: 'flex', gap: 0.75 }}>
+							<IconButton size='small' disabled={state === 'recording'} onClick={handleRecord}
+								sx={state === 'recording' ? { ...hwIconBtnLit(color), p: 0.75 } : { ...hwIconBtn(color), p: 0.75 }}>
+								<FiberManualRecordIcon sx={{ fontSize: 16 }} />
+							</IconButton>
+							<IconButton size='small' disabled={state !== 'recording' && state !== 'paused'} onClick={handlePause}
+								sx={state === 'paused' ? { ...hwIconBtnLit(color), p: 0.75 } : { ...hwIconBtn(color), p: 0.75 }}>
+								<PauseIcon sx={{ fontSize: 16 }} />
+							</IconButton>
+							<IconButton size='small' disabled={state !== 'recording' && state !== 'paused'} onClick={handleStop}
+								sx={{ ...hwIconBtn(color), p: 0.75 }}>
+								<StopIcon sx={{ fontSize: 16 }} />
+							</IconButton>
+						</Box>
+
+						<Typography variant='caption' color='text.secondary' sx={{ fontSize: 11, fontFamily: 'monospace' }}>
+							{formatDuration(state === 'stopped' ? finalDuration : elapsed)}
+						</Typography>
+
+						{state === 'stopped' && blobUrl && (
+							<Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25 }}>
+								<Typography variant='caption' color='text.disabled' sx={{ fontSize: 9 }}>
+									{formatSize(blobSize)}
+								</Typography>
+								<IconButton size='small' component='a' href={blobUrl} download={`recording-${id}.webm`}
+									sx={{ ...hwIconBtn(color), p: 0.75 }}>
+									<DownloadIcon sx={{ fontSize: 16 }} />
+								</IconButton>
+							</Box>
+						)}
+					</>
+				)}
+			</Box>
+
+			<Handle type='target' position={Position.Left} id='in-0' style={inputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/analysis/WaveformNode.tsx
+++ b/src/daw/nodes/analysis/WaveformNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useMemo, useRef } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import Box from '@mui/material/Box';
 import MenuItem from '@mui/material/MenuItem';
@@ -11,6 +11,7 @@ import { GRID_UNIT } from '../shared/gridSystem';
 import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
 import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx, HW_INSET } from '../shared/hwStyles';
+import { useCanvasReadout } from '../shared/useCanvasReadout';
 import { ANALYSIS_SIZE_OPTIONS, type WaveformFlowNode } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.utility;
@@ -20,39 +21,27 @@ const CANVAS_H = 48;
 export const WaveformNode = memo(function WaveformNode({ id, data, selected }: NodeProps<WaveformFlowNode>) {
 	const setNodeParam = useDawStore(s => s.setNodeParam);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
-	const rafRef = useRef<number>(0);
 	const sx = useMemo(() => ({
 		select:     hwSelectSx(color, 'small'),
 		selectMenu: hwSelectMenuProps(color),
 		menuItem:   hwMenuItemSx(color),
 	}), []);
 
-	useEffect(() => {
-		const draw = () => {
-			const canvas  = canvasRef.current;
-			const samples = getWaveformValue(id);
-			if (canvas && samples) {
-				const ctx = canvas.getContext('2d');
-				if (ctx) {
-					ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
-					ctx.strokeStyle = color;
-					ctx.lineWidth = 1;
-					ctx.beginPath();
-					const step = CANVAS_W / samples.length;
-					for (let i = 0; i < samples.length; i++) {
-						const x = i * step;
-						const y = (1 - (samples[i] + 1) / 2) * CANVAS_H;
-						if (i === 0) ctx.moveTo(x, y);
-						else ctx.lineTo(x, y);
-					}
-					ctx.stroke();
-				}
-			}
-			rafRef.current = requestAnimationFrame(draw);
-		};
-		rafRef.current = requestAnimationFrame(draw);
-		return () => cancelAnimationFrame(rafRef.current);
-	}, [id]);
+	useCanvasReadout(canvasRef, CANVAS_W, CANVAS_H, ctx => {
+		const samples = getWaveformValue(id);
+		if (!samples) return;
+		ctx.strokeStyle = color;
+		ctx.lineWidth = 1;
+		ctx.beginPath();
+		const step = CANVAS_W / samples.length;
+		for (let i = 0; i < samples.length; i++) {
+			const x = i * step;
+			const y = (1 - (samples[i] + 1) / 2) * CANVAS_H;
+			if (i === 0) ctx.moveTo(x, y);
+			else ctx.lineTo(x, y);
+		}
+		ctx.stroke();
+	});
 
 	return (
 		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>

--- a/src/daw/nodes/dynamics/CompressorNode.tsx
+++ b/src/daw/nodes/dynamics/CompressorNode.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { CompressorFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.dynamics;
+
+export const CompressorNode = memo(function CompressorNode({ id, data, selected }: NodeProps<CompressorFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Compressor' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='threshold' value={data.threshold} min={-100} max={0}  step={1}    color={color} onChange={v => setNodeParam(id, { threshold: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='ratio'     value={data.ratio}     min={1}    max={20} step={0.5}  color={color} onChange={v => setNodeParam(id, { ratio: v })}     format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='attack'    value={data.attack}    min={0}    max={1}  step={0.001} color={color} onChange={v => setNodeParam(id, { attack: v })}   format={v => v.toFixed(3)} unit='s'  allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='release'   value={data.release}   min={0}    max={1}  step={0.01}  color={color} onChange={v => setNodeParam(id, { release: v })}  format={v => v.toFixed(2)} unit='s'  allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='knee'      value={data.knee}      min={0}    max={40} step={1}     color={color} onChange={v => setNodeParam(id, { knee: v })}     format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/dynamics/CompressorNode.tsx
+++ b/src/daw/nodes/dynamics/CompressorNode.tsx
@@ -7,7 +7,7 @@ import { NODE_COLORS } from '../shared/nodeColors';
 import { GRID_UNIT } from '../shared/gridSystem';
 import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
 import { METAL_BG } from '../shared/metalBackground';
-import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import { CompressorControls } from '../shared/CompressorControls';
 import type { CompressorFlowNode } from '../../../store/dawTypes';
 
 const color = NODE_COLORS.dynamics;
@@ -19,12 +19,8 @@ export const CompressorNode = memo(function CompressorNode({ id, data, selected 
 		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
 			<NodeHeader id={id} label='Compressor' selected={selected} accentColor={color} filledHeader />
 
-			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
-				<HwArcSlider label='threshold' value={data.threshold} min={-100} max={0}  step={1}    color={color} onChange={v => setNodeParam(id, { threshold: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='ratio'     value={data.ratio}     min={1}    max={20} step={0.5}  color={color} onChange={v => setNodeParam(id, { ratio: v })}     format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='attack'    value={data.attack}    min={0}    max={1}  step={0.001} color={color} onChange={v => setNodeParam(id, { attack: v })}   format={v => v.toFixed(3)} unit='s'  allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='release'   value={data.release}   min={0}    max={1}  step={0.01}  color={color} onChange={v => setNodeParam(id, { release: v })}  format={v => v.toFixed(2)} unit='s'  allowValueEdit allowBoundsEdit />
-				<HwArcSlider label='knee'      value={data.knee}      min={0}    max={40} step={1}     color={color} onChange={v => setNodeParam(id, { knee: v })}     format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75 }} className='nodrag nowheel'>
+				<CompressorControls value={data} onChange={update => setNodeParam(id, update)} color={color} />
 			</Box>
 
 			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />

--- a/src/daw/nodes/dynamics/MidSideCompressorNode.tsx
+++ b/src/daw/nodes/dynamics/MidSideCompressorNode.tsx
@@ -1,0 +1,44 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { CompressorControls } from '../shared/CompressorControls';
+import type { MidSideCompressorFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.dynamics;
+
+export const MidSideCompressorNode = memo(function MidSideCompressorNode({ id, data, selected }: NodeProps<MidSideCompressorFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='MidSideCompressor' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 1, textAlign: 'center' }}>
+				<Typography variant='caption' color='text.disabled' sx={{ fontSize: 9 }}>
+					requires a stereo input signal
+				</Typography>
+			</Box>
+
+			<Box sx={{ px: 1.75, pt: 1, pb: 0.75, display: 'flex', gap: 2 }} className='nodrag nowheel'>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>mid</Typography>
+					<CompressorControls value={data.mid} onChange={update => setNodeParam(id, { mid: { ...data.mid, ...update } })} color={color} />
+				</Box>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>side</Typography>
+					<CompressorControls value={data.side} onChange={update => setNodeParam(id, { side: { ...data.side, ...update } })} color={color} />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/dynamics/MultibandCompressorNode.tsx
+++ b/src/daw/nodes/dynamics/MultibandCompressorNode.tsx
@@ -1,0 +1,54 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import { CompressorControls } from '../shared/CompressorControls';
+import type { MultibandCompressorFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.dynamics;
+
+// v1 UI shows threshold+ratio only per band — attack/release/knee stay at
+// their defaults (docs/node-roadmap.md: 17 live controls is too heavy).
+const BAND_PARAMS = ['threshold', 'ratio'] as const;
+
+export const MultibandCompressorNode = memo(function MultibandCompressorNode({ id, data, selected }: NodeProps<MultibandCompressorFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 7 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='MultibandCompressor' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 1, pb: 0.5, display: 'flex', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='low freq' value={data.lowFrequency}  min={20}  max={2000}  step={10} color={color}
+					onChange={v => setNodeParam(id, { lowFrequency: v })}  format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='hi freq'  value={data.highFrequency} min={200} max={20000} step={10} color={color}
+					onChange={v => setNodeParam(id, { highFrequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Box sx={{ px: 1.75, pb: 0.75, display: 'flex', gap: 1.5 }} className='nodrag nowheel'>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>low</Typography>
+					<CompressorControls value={data.low} onChange={update => setNodeParam(id, { low: { ...data.low, ...update } })} color={color} params={[...BAND_PARAMS]} />
+				</Box>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>mid</Typography>
+					<CompressorControls value={data.mid} onChange={update => setNodeParam(id, { mid: { ...data.mid, ...update } })} color={color} params={[...BAND_PARAMS]} />
+				</Box>
+				<Box sx={{ flex: 1 }}>
+					<Typography variant='caption' color='text.secondary' sx={{ fontSize: 10, display: 'block', textAlign: 'center', mb: 0.5 }}>high</Typography>
+					<CompressorControls value={data.high} onChange={update => setNodeParam(id, { high: { ...data.high, ...update } })} color={color} params={[...BAND_PARAMS]} />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/ChannelNode.tsx
+++ b/src/daw/nodes/processing/ChannelNode.tsx
@@ -1,0 +1,46 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwSwitch } from '../shared/hwComponents';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { ChannelFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+
+// PanVol + Solo internally composed (docs/node-roadmap.md). Solo state comes
+// from the store, not node data — same cross-instance pattern as SoloNode.tsx
+// (ADR-0003): Channel and Solo share Tone's own static solo registry, so
+// soloing this instance dims every other Solo/Channel node on the canvas.
+export const ChannelNode = memo(function ChannelNode({ id, data, selected }: NodeProps<ChannelFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const toggleSolo    = useDawStore(s => s.toggleSolo);
+	const soloedNodeId  = useDawStore(s => s.soloedNodeId);
+	const isSoloed       = soloedNodeId === id;
+	const isMutedByPeer  = soloedNodeId !== null && !isSoloed;
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', opacity: isMutedByPeer ? 0.55 : 1, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Channel' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='pan'    value={data.pan}    min={-1}  max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { pan: v })}    format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='volume' value={data.volume} min={-60} max={6} step={0.5}  color={color} onChange={v => setNodeParam(id, { volume: v })} format={v => v.toFixed(1)} unit='dB' allowValueEdit allowBoundsEdit />
+				</Box>
+				<Box sx={{ display: 'flex', gap: 1.5, justifyContent: 'center' }}>
+					<HwSwitch checked={data.mute} color={color} onChange={() => setNodeParam(id, { mute: !data.mute })} label='mute' />
+					<HwSwitch checked={isSoloed}  color={color} onChange={() => toggleSolo(id)}                          label='solo' />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/CrossFadeNode.tsx
+++ b/src/daw/nodes/processing/CrossFadeNode.tsx
@@ -1,0 +1,38 @@
+import { memo, Fragment } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle, inputLabel, computeHandleTops } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { CrossFadeFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const LABELS = ['a', 'b'];
+
+export const CrossFadeNode = memo(function CrossFadeNode({ id, data, selected }: NodeProps<CrossFadeFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const tops = computeHandleTops(2, 'normal');
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='CrossFade' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='fade' value={data.fade} min={0} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { fade: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+			</Box>
+
+			{tops.map((top, i) => (
+				<Fragment key={i}>
+					<Handle type='target' position={Position.Left} id={`in-${i}`} style={{ ...inputHandleStyle(color), top }} />
+					{inputLabel(LABELS[i], top, color)}
+				</Fragment>
+			))}
+
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/EQ3Node.tsx
+++ b/src/daw/nodes/processing/EQ3Node.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { EQ3FlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+
+export const EQ3Node = memo(function EQ3Node({ id, data, selected }: NodeProps<EQ3FlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='EQ3' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='low'      value={data.low}           min={-40} max={40}   step={0.5} color={color} onChange={v => setNodeParam(id, { low: v })}           format={v => v.toFixed(1)}          unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='mid'      value={data.mid}           min={-40} max={40}   step={0.5} color={color} onChange={v => setNodeParam(id, { mid: v })}           format={v => v.toFixed(1)}          unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='high'     value={data.high}          min={-40} max={40}   step={0.5} color={color} onChange={v => setNodeParam(id, { high: v })}          format={v => v.toFixed(1)}          unit='dB' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='low freq' value={data.lowFrequency}  min={20}  max={2000}  step={10}  color={color} onChange={v => setNodeParam(id, { lowFrequency: v })}  format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='hi freq'  value={data.highFrequency} min={200} max={20000} step={10}  color={color} onChange={v => setNodeParam(id, { highFrequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/FilterNode.tsx
+++ b/src/daw/nodes/processing/FilterNode.tsx
@@ -1,0 +1,60 @@
+import { memo, useMemo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx } from '../shared/hwStyles';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import { FILTER_ROLLOFF_OPTIONS, type FilterFlowNode, type BiquadFilterType, type FilterRolloff } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const FILTER_TYPES: BiquadFilterType[] = [
+	'lowpass', 'highpass', 'bandpass', 'lowshelf', 'highshelf', 'notch', 'allpass', 'peaking',
+];
+
+export const FilterNode = memo(function FilterNode({ id, data, selected }: NodeProps<FilterFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const sx = useMemo(() => ({
+		select:     hwSelectSx(color, 'small'),
+		selectMenu: hwSelectMenuProps(color),
+		menuItem:   hwMenuItemSx(color),
+	}), []);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Filter' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Box sx={{ display: 'flex', gap: 0.75 }}>
+					<Select value={data.type} onChange={e => setNodeParam(id, { type: e.target.value as BiquadFilterType })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{FILTER_TYPES.map(t => (
+							<MenuItem key={t} value={t} sx={sx.menuItem}>{t}</MenuItem>
+						))}
+					</Select>
+					<Select value={data.rolloff} onChange={e => setNodeParam(id, { rolloff: Number(e.target.value) as FilterRolloff })} fullWidth
+						sx={sx.select} MenuProps={sx.selectMenu}>
+						{FILTER_ROLLOFF_OPTIONS.map(r => (
+							<MenuItem key={r} value={r} sx={sx.menuItem}>{r}dB/oct</MenuItem>
+						))}
+					</Select>
+				</Box>
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='freq'   value={data.frequency} min={20}    max={20000} step={10}   color={color} onChange={v => setNodeParam(id, { frequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='Q'      value={data.Q}         min={0.001} max={100}   step={0.1}  color={color} onChange={v => setNodeParam(id, { Q: v })}         format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='detune' value={data.detune}    min={-1200} max={1200}  step={1}    color={color} onChange={v => setNodeParam(id, { detune: v })}    format={v => String(Math.round(v))}  unit='ct' allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='gain'   value={data.gain}      min={-40}   max={40}    step={0.5}  color={color} onChange={v => setNodeParam(id, { gain: v })}      format={v => v.toFixed(1)}           unit='dB' allowValueEdit allowBoundsEdit />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/MultibandSplitNode.tsx
+++ b/src/daw/nodes/processing/MultibandSplitNode.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader, NODE_HEADER_HEIGHT } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, bottomOutputHandleStyle, outputLabel } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { MultibandSplitFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const INPUT_TOP = `calc(${NODE_HEADER_HEIGHT}px + 20px)`;
+
+export const MultibandSplitNode = memo(function MultibandSplitNode({ id, data, selected }: NodeProps<MultibandSplitFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', pb: 2.5, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='MultibandSplit' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='low freq' value={data.lowFrequency}  min={20}  max={2000}  step={10}  color={color} onChange={v => setNodeParam(id, { lowFrequency: v })}  format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='hi freq'  value={data.highFrequency} min={200} max={20000} step={10}  color={color} onChange={v => setNodeParam(id, { highFrequency: v })} format={v => String(Math.round(v))} unit='Hz' allowValueEdit allowBoundsEdit />
+				<HwArcSlider label='Q'        value={data.Q}             min={0.1} max={10}    step={0.1} color={color} onChange={v => setNodeParam(id, { Q: v })}             format={v => v.toFixed(1)}           allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left} id='in-0' style={{ ...inputHandleStyle(color), top: INPUT_TOP }} />
+
+			<Handle type='source' position={Position.Bottom} id='out-0' style={{ ...bottomOutputHandleStyle(color), left: '25%' }} />
+			{outputLabel('low', color, '25%')}
+			<Handle type='source' position={Position.Bottom} id='out-1' style={{ ...bottomOutputHandleStyle(color), left: '50%' }} />
+			{outputLabel('mid', color, '50%')}
+			<Handle type='source' position={Position.Bottom} id='out-2' style={{ ...bottomOutputHandleStyle(color), left: '75%' }} />
+			{outputLabel('high', color, '75%')}
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/Panner3DNode.tsx
+++ b/src/daw/nodes/processing/Panner3DNode.tsx
@@ -1,0 +1,49 @@
+import { memo, useMemo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx } from '../shared/hwStyles';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { Panner3DFlowNode, Panner3DPanningModel } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const PANNING_MODELS: Panner3DPanningModel[] = ['equalpower', 'HRTF'];
+
+export const Panner3DNode = memo(function Panner3DNode({ id, data, selected }: NodeProps<Panner3DFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const sx = useMemo(() => ({
+		select:     hwSelectSx(color, 'small'),
+		selectMenu: hwSelectMenuProps(color),
+		menuItem:   hwMenuItemSx(color),
+	}), []);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 3 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Panner3D' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Select value={data.panningModel} onChange={e => setNodeParam(id, { panningModel: e.target.value as Panner3DPanningModel })} fullWidth
+					sx={sx.select} MenuProps={sx.selectMenu}>
+					{PANNING_MODELS.map(m => (
+						<MenuItem key={m} value={m} sx={sx.menuItem}>{m}</MenuItem>
+					))}
+				</Select>
+				<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+					<HwArcSlider label='x' value={data.positionX} min={-10} max={10} step={0.1} color={color} onChange={v => setNodeParam(id, { positionX: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='y' value={data.positionY} min={-10} max={10} step={0.1} color={color} onChange={v => setNodeParam(id, { positionY: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+					<HwArcSlider label='z' value={data.positionZ} min={-10} max={10} step={0.1} color={color} onChange={v => setNodeParam(id, { positionZ: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+				</Box>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/PannerNode.tsx
+++ b/src/daw/nodes/processing/PannerNode.tsx
@@ -1,0 +1,35 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader, NODE_HEADER_HEIGHT } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, bottomOutputHandleStyle, outputLabel } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { PannerFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+const INPUT_TOP = `calc(${NODE_HEADER_HEIGHT}px + 20px)`;
+
+export const PannerNode = memo(function PannerNode({ id, data, selected }: NodeProps<PannerFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2 * GRID_UNIT, position: 'relative', pb: 2.5, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Panner' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwArcSlider label='pan' value={data.pan} min={-1} max={1} step={0.01} color={color} onChange={v => setNodeParam(id, { pan: v })} format={v => v.toFixed(2)} allowValueEdit allowBoundsEdit />
+			</Box>
+
+			<Handle type='target' position={Position.Left} id='in-0' style={{ ...inputHandleStyle(color), top: INPUT_TOP }} />
+
+			<Handle type='source' position={Position.Bottom} id='out-0' style={{ ...bottomOutputHandleStyle(color), left: '33%' }} />
+			{outputLabel('L', color, '33%')}
+			<Handle type='source' position={Position.Bottom} id='out-1' style={{ ...bottomOutputHandleStyle(color), left: '67%' }} />
+			{outputLabel('R', color, '67%')}
+		</Box>
+	);
+});

--- a/src/daw/nodes/processing/SoloNode.tsx
+++ b/src/daw/nodes/processing/SoloNode.tsx
@@ -1,0 +1,33 @@
+import { memo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { HwSwitch } from '../shared/hwComponents';
+import type { SoloFlowNode } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.processor;
+
+export const SoloNode = memo(function SoloNode({ id, selected }: NodeProps<SoloFlowNode>) {
+	const toggleSolo   = useDawStore(s => s.toggleSolo);
+	const soloedNodeId = useDawStore(s => s.soloedNodeId);
+	const isSoloed      = soloedNodeId === id;
+	const isMutedByPeer = soloedNodeId !== null && !isSoloed;
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 1.5 * GRID_UNIT, position: 'relative', opacity: isMutedByPeer ? 0.55 : 1, boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='Solo' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', justifyContent: 'center' }} className='nodrag nowheel'>
+				<HwSwitch checked={isSoloed} color={color} onChange={() => toggleSolo(id)} label='solo' />
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/nodes/shared/CompressorControls.tsx
+++ b/src/daw/nodes/shared/CompressorControls.tsx
@@ -1,0 +1,45 @@
+import Box from '@mui/material/Box';
+import { HwArcSlider } from '../../../components/hw/HwArcSlider';
+import type { CompressorBandData } from '../../../store/dawTypes';
+
+const ALL_PARAMS: (keyof CompressorBandData)[] = ['threshold', 'ratio', 'attack', 'release', 'knee'];
+
+type Props = {
+	value:    CompressorBandData;
+	onChange: (update: Partial<CompressorBandData>) => void;
+	color:    string;
+	/** Which sliders to show — defaults to all 5. MultibandCompressor's v1 scope shows threshold+ratio only (docs/node-roadmap.md). */
+	params?:  (keyof CompressorBandData)[];
+};
+
+/**
+ * The threshold/ratio/attack/release/knee slider row every real Compressor
+ * band needs — standalone Compressor, and each band of MidSideCompressor/
+ * MultibandCompressor (docs/adr/0004-nested-param-panel-layout.md).
+ */
+export function CompressorControls({ value, onChange, color, params = ALL_PARAMS }: Props) {
+	return (
+		<Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center' }}>
+			{params.includes('threshold') && (
+				<HwArcSlider label='threshold' value={value.threshold} min={-100} max={0} step={1} color={color}
+					onChange={v => onChange({ threshold: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('ratio') && (
+				<HwArcSlider label='ratio' value={value.ratio} min={1} max={20} step={0.5} color={color}
+					onChange={v => onChange({ ratio: v })} format={v => v.toFixed(1)} allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('attack') && (
+				<HwArcSlider label='attack' value={value.attack} min={0} max={1} step={0.001} color={color}
+					onChange={v => onChange({ attack: v })} format={v => v.toFixed(3)} unit='s' allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('release') && (
+				<HwArcSlider label='release' value={value.release} min={0} max={1} step={0.01} color={color}
+					onChange={v => onChange({ release: v })} format={v => v.toFixed(2)} unit='s' allowValueEdit allowBoundsEdit />
+			)}
+			{params.includes('knee') && (
+				<HwArcSlider label='knee' value={value.knee} min={0} max={40} step={1} color={color}
+					onChange={v => onChange({ knee: v })} format={v => v.toFixed(0)} unit='dB' allowValueEdit allowBoundsEdit />
+			)}
+		</Box>
+	);
+}

--- a/src/daw/nodes/shared/StubNode.tsx
+++ b/src/daw/nodes/shared/StubNode.tsx
@@ -12,8 +12,6 @@ import type { StubFlowNode, StubKind } from '../../../store/dawTypes';
 // Only entries that differ from the default mono in → mono out topology.
 const STUB_TOPOLOGY: Partial<Record<StubKind, { inputs: string[]; outputs: string[] }>> = {
 	noiseGenerator: { inputs: [],               outputs: ['out-0'] },
-	panner:         { inputs: ['in-0'],         outputs: ['out-0', 'out-1'] },
-	crossFade:      { inputs: ['in-0', 'in-1'], outputs: ['out-0'] },
 	// Source-like stubs (instruments, oscillators) have no audio input
 	synth:          { inputs: [], outputs: ['out-0'] },
 	monoSynth:      { inputs: [], outputs: ['out-0'] },

--- a/src/daw/nodes/shared/StubNode.tsx
+++ b/src/daw/nodes/shared/StubNode.tsx
@@ -13,7 +13,6 @@ import type { StubFlowNode, StubKind } from '../../../store/dawTypes';
 const STUB_TOPOLOGY: Partial<Record<StubKind, { inputs: string[]; outputs: string[] }>> = {
 	noiseGenerator: { inputs: [],               outputs: ['out-0'] },
 	panner:         { inputs: ['in-0'],         outputs: ['out-0', 'out-1'] },
-	multibandSplit: { inputs: ['in-0'],         outputs: ['out-0', 'out-1', 'out-2'] },
 	crossFade:      { inputs: ['in-0', 'in-1'], outputs: ['out-0'] },
 	// Source-like stubs (instruments, oscillators) have no audio input
 	synth:          { inputs: [], outputs: ['out-0'] },

--- a/src/daw/nodes/shared/hwComponents.tsx
+++ b/src/daw/nodes/shared/hwComponents.tsx
@@ -10,7 +10,7 @@ type HwToggleButtonGroupProps = {
 	color: string;
 	/** Number of equal-width columns. Omit for a horizontal strip layout. */
 	cols?: number;
-} & Omit<ToggleButtonGroupProps, 'sx'>;
+} & Omit<ToggleButtonGroupProps, 'sx' | 'color'>;
 
 export function HwToggleButtonGroup({ color, cols, children, ...props }: HwToggleButtonGroupProps) {
 	const sx = cols ? hwGridToggleSx(color, cols) : hwToggleSx(color);
@@ -26,8 +26,9 @@ type HwButtonProps = { color: string; lit?: boolean } & Omit<ButtonProps, 'color
 
 export function HwButton({ color, lit = false, sx: sxProp, children, ...props }: HwButtonProps) {
 	const base = lit ? hwBtnLit(color) : hwBtn(color);
+	const sx = sxProp ? [base, ...(Array.isArray(sxProp) ? sxProp : [sxProp])] : [base];
 	return (
-		<Button sx={sxProp ? [base, sxProp] : base} {...props}>
+		<Button sx={sx} {...props}>
 			{children}
 		</Button>
 	);

--- a/src/daw/nodes/shared/hwStyles.ts
+++ b/src/daw/nodes/shared/hwStyles.ts
@@ -165,13 +165,15 @@ export function hwMenuItemSx(color: string) {
 
 export function hwSelectMenuProps(color: string) {
 	return {
-		PaperProps: {
-			sx: {
-				background:   '#1a1a1e',
-				border:       '1px solid #0d0d0f',
-				borderColor:  `${color}40`,
-				boxShadow:    `0 4px 12px rgba(0,0,0,0.7), 0 0 0 1px ${color}20`,
-				'& .MuiMenuItem-root': hwMenuItemSx(color),
+		slotProps: {
+			paper: {
+				sx: {
+					background:   '#1a1a1e',
+					border:       '1px solid #0d0d0f',
+					borderColor:  `${color}40`,
+					boxShadow:    `0 4px 12px rgba(0,0,0,0.7), 0 0 0 1px ${color}20`,
+					'& .MuiMenuItem-root': hwMenuItemSx(color),
+				},
 			},
 		},
 	};

--- a/src/daw/nodes/shared/useCanvasReadout.ts
+++ b/src/daw/nodes/shared/useCanvasReadout.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * Drives a requestAnimationFrame loop that clears a canvas and hands its 2D
+ * context to `draw` every frame. `draw` is read from a ref so the loop never
+ * restarts on re-render — only `width`/`height` changes tear it down and
+ * restart it, matching ADR-0001's scope: the FFT/Waveform/Analyser rendering
+ * shape, not the setInterval+React-state shape Meter/DCMeter use.
+ */
+export function useCanvasReadout(
+	canvasRef: RefObject<HTMLCanvasElement | null>,
+	width:     number,
+	height:    number,
+	draw:      (ctx: CanvasRenderingContext2D) => void,
+): void {
+	const drawRef = useRef(draw);
+	drawRef.current = draw;
+
+	useEffect(() => {
+		const rafRef = { current: 0 };
+		const tick = () => {
+			const canvas = canvasRef.current;
+			const ctx    = canvas?.getContext('2d');
+			if (ctx) {
+				ctx.clearRect(0, 0, width, height);
+				drawRef.current(ctx);
+			}
+			rafRef.current = requestAnimationFrame(tick);
+		};
+		rafRef.current = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(rafRef.current);
+	}, [canvasRef, width, height]);
+}

--- a/src/daw/nodes/signal/WaveShaperNode.tsx
+++ b/src/daw/nodes/signal/WaveShaperNode.tsx
@@ -1,0 +1,56 @@
+import { memo, useMemo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import Box from '@mui/material/Box';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import ToggleButton from '@mui/material/ToggleButton';
+import { useDawStore } from '../../../store/daw';
+import { NodeHeader } from '../shared/NodeHeader';
+import { NODE_COLORS } from '../shared/nodeColors';
+import { GRID_UNIT } from '../shared/gridSystem';
+import { inputHandleStyle, outputHandleStyle } from '../shared/handleStyles';
+import { METAL_BG } from '../shared/metalBackground';
+import { hwSelectSx, hwSelectMenuProps, hwMenuItemSx } from '../shared/hwStyles';
+import { HwToggleButtonGroup } from '../shared/hwComponents';
+import type { WaveShaperFlowNode, WaveShaperPreset } from '../../../store/dawTypes';
+
+const color = NODE_COLORS.utility;
+const PRESETS: { value: WaveShaperPreset; label: string }[] = [
+	{ value: 'identity', label: 'identity' },
+	{ value: 'softClip', label: 'soft clip' },
+	{ value: 'hardClip', label: 'hard clip' },
+];
+const OVERSAMPLE_OPTIONS = ['none', '2x', '4x'] as const;
+
+export const WaveShaperNode = memo(function WaveShaperNode({ id, data, selected }: NodeProps<WaveShaperFlowNode>) {
+	const setNodeParam = useDawStore(s => s.setNodeParam);
+	const sx = useMemo(() => ({
+		select:     hwSelectSx(color, 'small'),
+		selectMenu: hwSelectMenuProps(color),
+		menuItem:   hwMenuItemSx(color),
+	}), []);
+
+	return (
+		<Box sx={{ borderRadius: 1, backgroundImage: METAL_BG, width: 2.5 * GRID_UNIT, position: 'relative', boxShadow: selected ? `0px 4px 15px ${color}4d` : '0px 4px 15px rgba(0,0,0,0.30)' }}>
+			<NodeHeader id={id} label='WaveShaper' selected={selected} accentColor={color} filledHeader />
+
+			<Box sx={{ px: 1.75, pt: 2, pb: 0.75, display: 'flex', flexDirection: 'column', gap: 0.75 }} className='nodrag nowheel'>
+				<Select value={data.preset} onChange={e => setNodeParam(id, { preset: e.target.value as WaveShaperPreset })} fullWidth
+					sx={sx.select} MenuProps={sx.selectMenu}>
+					{PRESETS.map(p => (
+						<MenuItem key={p.value} value={p.value} sx={sx.menuItem}>{p.label}</MenuItem>
+					))}
+				</Select>
+				<HwToggleButtonGroup color={color} value={data.oversample} exclusive
+					onChange={(_, v) => v && setNodeParam(id, { oversample: v })} className='nodrag'>
+					{OVERSAMPLE_OPTIONS.map(opt => (
+						<ToggleButton key={opt} value={opt}>{opt}</ToggleButton>
+					))}
+				</HwToggleButtonGroup>
+			</Box>
+
+			<Handle type='target' position={Position.Left}  id='in-0'  style={inputHandleStyle(color)} />
+			<Handle type='source' position={Position.Right} id='out-0' style={outputHandleStyle(color)} />
+		</Box>
+	);
+});

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -489,6 +489,7 @@ const REAL_ACTIONS = new Set<string>([
 	'crossFade',
 	'panner',
 	'panner3d',
+	'waveShaper',
 	'midSideCompressor',
 	'multibandCompressor',
 ]);

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -488,6 +488,7 @@ const REAL_ACTIONS = new Set<string>([
 	'solo',
 	'crossFade',
 	'panner',
+	'midSideCompressor',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -486,6 +486,8 @@ const REAL_ACTIONS = new Set<string>([
 	'analyser',
 	'follower',
 	'solo',
+	'crossFade',
+	'panner',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -489,6 +489,7 @@ const REAL_ACTIONS = new Set<string>([
 	'crossFade',
 	'panner',
 	'midSideCompressor',
+	'multibandCompressor',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -490,6 +490,7 @@ const REAL_ACTIONS = new Set<string>([
 	'panner',
 	'panner3d',
 	'waveShaper',
+	'recorder',
 	'midSideCompressor',
 	'multibandCompressor',
 ]);

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -479,6 +479,12 @@ const REAL_ACTIONS = new Set<string>([
 	'negate',
 	'audioToGain',
 	'gainToAudio',
+	'compressor',
+	'filter',
+	'eq3',
+	'multibandSplit',
+	'analyser',
+	'follower',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -493,6 +493,7 @@ const REAL_ACTIONS = new Set<string>([
 	'recorder',
 	'midSideCompressor',
 	'multibandCompressor',
+	'channel',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -485,6 +485,7 @@ const REAL_ACTIONS = new Set<string>([
 	'multibandSplit',
 	'analyser',
 	'follower',
+	'solo',
 ]);
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -488,6 +488,7 @@ const REAL_ACTIONS = new Set<string>([
 	'solo',
 	'crossFade',
 	'panner',
+	'panner3d',
 	'midSideCompressor',
 	'multibandCompressor',
 ]);

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -110,7 +110,6 @@ const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
-	waveShaper:          'WaveShaper',
 	greaterThan:         'GreaterThan',
 	toneEvent:           'ToneEvent',
 };

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -111,7 +111,6 @@ const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	midSideCompressor:   'MidSideCompressor',
 	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
-	crossFade:           'CrossFade',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
 	waveShaper:          'WaveShaper',

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -160,6 +160,7 @@ type DawState = {
 	selectedNodeId: string | null;
 	sceneRunning:   boolean;
 	playingNodes:   Set<string>;
+	soloedNodeId:   string | null;
 
 	onNodesChange:     OnNodesChange<AppNode>;
 	onEdgesChange:     OnEdgesChange<AppEdge>;
@@ -174,6 +175,7 @@ type DawState = {
 	updateNodeData:      (id: string, data: Partial<Record<string, unknown>>) => void;
 	updateNodePositions: (updatedNodes: AppNode[]) => void;
 	setSelectedNodeId:   (id: string | null) => void;
+	toggleSolo:          (id: string) => void;
 	setSpeakersMuted:    (muted: boolean) => void;
 	edgePathType:        'bezier' | 'straight' | 'step' | 'smoothstep';
 	setEdgePathType:     (type: 'bezier' | 'straight' | 'step' | 'smoothstep') => void;
@@ -191,6 +193,7 @@ export const useDawStore = create<DawState>((set, get) => ({
 	selectedNodeId: null,
 	sceneRunning:   false,
 	playingNodes:   new Set<string>(),
+	soloedNodeId:   null,
 
 	setNodePlaying: (id, playing) => set(state => {
 		const next = new Set(state.playingNodes);
@@ -215,7 +218,11 @@ export const useDawStore = create<DawState>((set, get) => ({
 			set(state => {
 				const next = new Set(state.playingNodes);
 				removed.forEach(id => next.delete(id));
-				return { nodes: applyNodeChanges(changes, state.nodes), playingNodes: next };
+				return {
+					nodes:        applyNodeChanges(changes, state.nodes),
+					playingNodes: next,
+					soloedNodeId: state.soloedNodeId && removed.includes(state.soloedNodeId) ? null : state.soloedNodeId,
+				};
 			});
 		} else {
 			set({ nodes: applyNodeChanges(changes, get().nodes) });
@@ -350,6 +357,21 @@ export const useDawStore = create<DawState>((set, get) => ({
 
 	setSelectedNodeId: (id) => set({ selectedNodeId: id }),
 
+	// Only one Solo/Channel instance can be soloed at a time (Tone.Solo's own
+	// static registry enforces this on the audio side, ADR-0003) — this field
+	// is the UI's mirror of that, letting every Solo node's component dim
+	// itself when a *different* instance is the soloed one.
+	toggleSolo: (id) => {
+		const current = get().soloedNodeId;
+		if (current === id) {
+			engine.setSoloed(id, false);
+			set({ soloedNodeId: null });
+		} else {
+			engine.setSoloed(id, true);
+			set({ soloedNodeId: id });
+		}
+	},
+
 	setSpeakersMuted: (muted) => {
 		engine.setSpeakersMuted(muted);
 		set({
@@ -417,6 +439,7 @@ export const useDawStore = create<DawState>((set, get) => ({
 			sceneRunning:   false,
 			selectedNodeId: null,
 			playingNodes:   new Set<string>(),
+			soloedNodeId:   null,
 		});
 	},
 

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -108,7 +108,6 @@ function edgeColorForSource(sourceId: string, nodes: AppNode[]): string {
 // Everything else falls back to capitalising the action string.
 const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
-	panner3d:            'Panner3D',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
 	waveShaper:          'WaveShaper',

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -108,7 +108,6 @@ function edgeColorForSource(sourceId: string, nodes: AppNode[]): string {
 // Everything else falls back to capitalising the action string.
 const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
-	midSideCompressor:   'MidSideCompressor',
 	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
 	amplitudeEnvelope:   'AmplitudeEnvelope',

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -112,7 +112,6 @@ const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
 	crossFade:           'CrossFade',
-	multibandSplit:      'MultibandSplit',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',
 	waveShaper:          'WaveShaper',

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -108,7 +108,6 @@ function edgeColorForSource(sourceId: string, nodes: AppNode[]): string {
 // Everything else falls back to capitalising the action string.
 const STUB_LABELS: Partial<Record<StubKind, string>> = {
 	noiseGenerator:      'Noise',
-	multibandCompressor: 'MultibandCompressor',
 	panner3d:            'Panner3D',
 	amplitudeEnvelope:   'AmplitudeEnvelope',
 	frequencyEnvelope:   'FrequencyEnvelope',

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper, Recorder } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -46,7 +46,6 @@ export type StubKind =
 	| 'channel'
 	| 'convolver'
 	// — Analysis —
-	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
 	// — Signal —
 	| 'add' | 'multiply' | 'greaterThan'
@@ -530,6 +529,13 @@ export type FollowerNodeData = {
 };
 export type FollowerFlowNode = Node<FollowerNodeData, 'follower'>;
 
+// Sink — in-0 only, no output, cannot chain further downstream. No live params
+// (mimeType is constructor-only on Tone's Recorder — see ADR-0006); recording
+// state/blob live in the audio entry and component-local UI state, driven by
+// recorder.ts's own start/pause/stop functions, not setAudioParam.
+export type RecorderNodeData = { label: string };
+export type RecorderFlowNode = Node<RecorderNodeData, 'recorder'>;
+
 // ─── Signal node data types ────────────────────────────────────────────────────
 
 export type SignalNodeData = {
@@ -639,6 +645,7 @@ export type AppNode =
 	| WaveformFlowNode
 	| AnalyserFlowNode
 	| FollowerFlowNode
+	| RecorderFlowNode
 	| SignalFlowNode
 	| ScaleFlowNode
 	| ScaleExpFlowNode
@@ -801,6 +808,7 @@ export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
 export type WaveformAudioEntry    = { kind: 'waveform';    toneNode: Waveform };
 export type AnalyserAudioEntry    = { kind: 'analyser';    toneNode: Analyser };
 export type FollowerAudioEntry    = { kind: 'follower';    toneNode: Follower };
+export type RecorderAudioEntry    = { kind: 'recorder';    toneNode: Recorder };
 export type SignalNodeAudioEntry  = { kind: 'signal';      toneNode: Signal<'number'> };
 export type ScaleAudioEntry       = { kind: 'scale';       toneNode: Scale };
 export type ScaleExpAudioEntry    = { kind: 'scaleExp';    toneNode: ScaleExp };
@@ -871,6 +879,7 @@ export type AudioNodeEntry =
 	| WaveformAudioEntry
 	| AnalyserAudioEntry
 	| FollowerAudioEntry
+	| RecorderAudioEntry
 	| SignalNodeAudioEntry
 	| ScaleAudioEntry
 	| ScaleExpAudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -43,7 +43,7 @@ export type StubKind =
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
 	// — Processing —
-	| 'channel' | 'panner3d'
+	| 'channel'
 	| 'convolver'
 	// — Analysis —
 	| 'recorder'
@@ -466,6 +466,20 @@ export type CrossFadeNodeData = {
 };
 export type CrossFadeFlowNode = Node<CrossFadeNodeData, 'crossFade'>;
 
+// v1 UI exposes only position + panningModel (docs/node-roadmap.md) — the
+// listener-cone/distance-falloff params (orientationX/Y/Z, distanceModel,
+// refDistance, maxDistance, rolloffFactor, coneInnerAngle/OuterAngle/
+// OuterGain) stay at their Tone.js defaults, ~14 controls is too heavy for v1.
+export type Panner3DPanningModel = 'equalpower' | 'HRTF';
+export type Panner3DNodeData = {
+	label:        string;
+	positionX:    number;   // default 0
+	positionY:    number;   // default 0
+	positionZ:    number;   // default 0
+	panningModel: Panner3DPanningModel; // default 'equalpower'
+};
+export type Panner3DFlowNode = Node<Panner3DNodeData, 'panner3d'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
@@ -606,6 +620,7 @@ export type AppNode =
 	| SoloFlowNode
 	| PannerFlowNode
 	| CrossFadeFlowNode
+	| Panner3DFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
@@ -766,6 +781,7 @@ export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: Multi
 export type SoloAudioEntry        = { kind: 'solo';        toneNode: Solo };
 export type PannerAudioEntry      = { kind: 'panner';      toneNode: Panner; split: Split };
 export type CrossFadeAudioEntry   = { kind: 'crossFade';   toneNode: CrossFade };
+export type Panner3DAudioEntry    = { kind: 'panner3d';    toneNode: Panner3D };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
@@ -834,6 +850,7 @@ export type AudioNodeEntry =
 	| SoloAudioEntry
 	| PannerAudioEntry
 	| CrossFadeAudioEntry
+	| Panner3DAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -36,7 +36,7 @@ export type GainNodeData = {
 
 export type StubKind =
 	// — existing processing stubs (not yet implemented) —
-	| 'filter' | 'compressor' | 'noiseGenerator' | 'panner'
+	| 'noiseGenerator' | 'panner'
 	// — Source / Instrument —
 	| 'omniOscillator'
 	| 'players' | 'userMedia'
@@ -45,10 +45,10 @@ export type StubKind =
 	// — Dynamics —
 	| 'midSideCompressor' | 'multibandCompressor'
 	// — Processing —
-	| 'eq3' | 'channel' | 'panner3d' | 'crossFade'
-	| 'multibandSplit' | 'solo' | 'convolver'
+	| 'channel' | 'panner3d' | 'crossFade'
+	| 'solo' | 'convolver'
 	// — Analysis —
-	| 'analyser' | 'follower' | 'recorder'
+	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
 	// — Signal —
 	| 'waveShaper' | 'add' | 'multiply' | 'greaterThan'
@@ -341,9 +341,21 @@ export type GateNodeData = {
 };
 export type GateFlowNode = Node<GateNodeData, 'gate'>;
 
+export type CompressorNodeData = {
+	label:     string;
+	threshold: number;   // dB, -100–0, default -24
+	ratio:     number;   // 1–20, default 12
+	attack:    number;   // seconds, 0–1, default 0.003
+	release:   number;   // seconds, 0–1, default 0.25
+	knee:      number;   // dB, 0–40, default 30
+};
+export type CompressorFlowNode = Node<CompressorNodeData, 'compressor'>;
+
 // ─── Processing node data types ───────────────────────────────────────────────
 
 export type BiquadFilterType = 'lowpass' | 'highpass' | 'bandpass' | 'lowshelf' | 'highshelf' | 'notch' | 'allpass' | 'peaking';
+export const FILTER_ROLLOFF_OPTIONS = [-12, -24, -48, -96] as const;
+export type FilterRolloff = typeof FILTER_ROLLOFF_OPTIONS[number];
 
 export type BiquadFilterNodeData = {
 	label:     string;
@@ -354,6 +366,27 @@ export type BiquadFilterNodeData = {
 	gain:      number;           // dB, -40–40, default 0 (lowshelf/highshelf/peaking only)
 };
 export type BiquadFilterFlowNode = Node<BiquadFilterNodeData, 'biquadFilter'>;
+
+export type FilterNodeData = {
+	label:     string;
+	frequency: number;           // Hz, 20–20000, default 350
+	type:      BiquadFilterType; // default 'lowpass'
+	rolloff:   FilterRolloff;    // default -12
+	Q:         number;           // 0.001–100, default 1
+	detune:    number;           // cents, -1200–1200, default 0
+	gain:      number;           // dB, -40–40, default 0 (lowshelf/highshelf/peaking only)
+};
+export type FilterFlowNode = Node<FilterNodeData, 'filter'>;
+
+export type EQ3NodeData = {
+	label:         string;
+	low:           number;   // dB, -40–40, default 0
+	mid:           number;   // dB, -40–40, default 0
+	high:          number;   // dB, -40–40, default 0
+	lowFrequency:  number;   // Hz, 20–2000, default 400
+	highFrequency: number;   // Hz, 200–20000, default 2500
+};
+export type EQ3FlowNode = Node<EQ3NodeData, 'eq3'>;
 
 export type PanVolNodeData = {
 	label:  string;
@@ -379,10 +412,18 @@ export type VolumeNodeData = {
 };
 export type VolumeFlowNode = Node<VolumeNodeData, 'volume'>;
 
+export type MultibandSplitNodeData = {
+	label:         string;
+	lowFrequency:  number;   // Hz, 20–2000, default 400
+	highFrequency: number;   // Hz, 200–20000, default 2500
+	Q:             number;   // 0.1–10, default 1
+};
+export type MultibandSplitFlowNode = Node<MultibandSplitNodeData, 'multibandSplit'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
-// getFFTValue/getMeterValue/getDCMeterValue/getWaveformValue.
+// getFFTValue/getMeterValue/getDCMeterValue/getWaveformValue/getAnalyserValue.
 
 export const ANALYSIS_SIZE_OPTIONS = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384] as const;
 export type AnalysisSize = typeof ANALYSIS_SIZE_OPTIONS[number];
@@ -410,6 +451,24 @@ export type WaveformNodeData = {
 	size:  AnalysisSize;   // power of two, default 1024
 };
 export type WaveformFlowNode = Node<WaveformNodeData, 'waveform'>;
+
+export type AnalyserType = 'fft' | 'waveform';
+
+export type AnalyserNodeData = {
+	label:     string;
+	size:      AnalysisSize;   // power of two, default 1024
+	type:      AnalyserType;   // default 'fft'
+	smoothing: number;         // 0–1, default 0.8
+};
+export type AnalyserFlowNode = Node<AnalyserNodeData, 'analyser'>;
+
+// Follower is not a tap despite living in the Analysis catalogue bucket — it's
+// a real processor (in-0 → out-0, no readout): see docs/node-roadmap.md.
+export type FollowerNodeData = {
+	label:     string;
+	smoothing: number;   // seconds, 0.001–1, default 0.05
+};
+export type FollowerFlowNode = Node<FollowerNodeData, 'follower'>;
 
 // ─── Signal node data types ────────────────────────────────────────────────────
 
@@ -486,16 +545,22 @@ export type AppNode =
 	| AutoWahFlowNode
 	| LimiterFlowNode
 	| GateFlowNode
+	| CompressorFlowNode
 	| BiquadFilterFlowNode
+	| FilterFlowNode
+	| EQ3FlowNode
 	| PanVolFlowNode
 	| SplitFlowNode
 	| MergeFlowNode
 	| MonoFlowNode
 	| VolumeFlowNode
+	| MultibandSplitFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
 	| WaveformFlowNode
+	| AnalyserFlowNode
+	| FollowerFlowNode
 	| SignalFlowNode
 	| ScaleFlowNode
 	| ScaleExpFlowNode
@@ -635,16 +700,22 @@ export type AutoWahAudioEntry         = { kind: 'autoWah';          toneNode: Au
 
 export type LimiterAudioEntry     = { kind: 'limiter';     toneNode: Limiter };
 export type GateAudioEntry        = { kind: 'gate';        toneNode: Gate };
+export type CompressorAudioEntry  = { kind: 'compressor';  toneNode: Compressor };
 export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFilter };
+export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
+export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
 export type PanVolAudioEntry      = { kind: 'panVol';      toneNode: PanVol };
 export type SplitNodeAudioEntry   = { kind: 'split';       toneNode: Split };
 export type MergeNodeAudioEntry   = { kind: 'merge';       toneNode: Merge };
 export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
 export type VolumeAudioEntry      = { kind: 'volume';      toneNode: Volume };
+export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: MultibandSplit };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
 export type WaveformAudioEntry    = { kind: 'waveform';    toneNode: Waveform };
+export type AnalyserAudioEntry    = { kind: 'analyser';    toneNode: Analyser };
+export type FollowerAudioEntry    = { kind: 'follower';    toneNode: Follower };
 export type SignalNodeAudioEntry  = { kind: 'signal';      toneNode: Signal<'number'> };
 export type ScaleAudioEntry       = { kind: 'scale';       toneNode: Scale };
 export type ScaleExpAudioEntry    = { kind: 'scaleExp';    toneNode: ScaleExp };
@@ -692,16 +763,22 @@ export type AudioNodeEntry =
 	| AutoWahAudioEntry
 	| LimiterAudioEntry
 	| GateAudioEntry
+	| CompressorAudioEntry
 	| BiquadFilterAudioEntry
+	| FilterAudioEntry
+	| EQ3AudioEntry
 	| PanVolAudioEntry
 	| SplitNodeAudioEntry
 	| MergeNodeAudioEntry
 	| MonoAudioEntry
 	| VolumeAudioEntry
+	| MultibandSplitAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry
 	| WaveformAudioEntry
+	| AnalyserAudioEntry
+	| FollowerAudioEntry
 	| SignalNodeAudioEntry
 	| ScaleAudioEntry
 	| ScaleExpAudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -36,7 +36,7 @@ export type GainNodeData = {
 
 export type StubKind =
 	// — existing processing stubs (not yet implemented) —
-	| 'noiseGenerator' | 'panner'
+	| 'noiseGenerator'
 	// — Source / Instrument —
 	| 'omniOscillator'
 	| 'players' | 'userMedia'
@@ -45,7 +45,7 @@ export type StubKind =
 	// — Dynamics —
 	| 'midSideCompressor' | 'multibandCompressor'
 	// — Processing —
-	| 'channel' | 'panner3d' | 'crossFade'
+	| 'channel' | 'panner3d'
 	| 'convolver'
 	// — Analysis —
 	| 'recorder'
@@ -426,6 +426,22 @@ export type MultibandSplitFlowNode = Node<MultibandSplitNodeData, 'multibandSpli
 export type SoloNodeData = { label: string };
 export type SoloFlowNode = Node<SoloNodeData, 'solo'>;
 
+// Panner wraps a single stereo StereoPannerNode — it has no native separate
+// L/R outputs. out-0/out-1 are a reactoscope design choice, satisfied by an
+// internal Split(2) the handler wires the panner's output into.
+export type PannerNodeData = {
+	label: string;
+	pan:   number;   // -1–1, default 0
+};
+export type PannerFlowNode = Node<PannerNodeData, 'panner'>;
+
+// CrossFade has no single `.input` — in-0/in-1 wire directly to toneNode.a/.b.
+export type CrossFadeNodeData = {
+	label: string;
+	fade:  number;   // 0–1, default 0.5
+};
+export type CrossFadeFlowNode = Node<CrossFadeNodeData, 'crossFade'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
@@ -562,6 +578,8 @@ export type AppNode =
 	| VolumeFlowNode
 	| MultibandSplitFlowNode
 	| SoloFlowNode
+	| PannerFlowNode
+	| CrossFadeFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
@@ -718,6 +736,8 @@ export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
 export type VolumeAudioEntry      = { kind: 'volume';      toneNode: Volume };
 export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: MultibandSplit };
 export type SoloAudioEntry        = { kind: 'solo';        toneNode: Solo };
+export type PannerAudioEntry      = { kind: 'panner';      toneNode: Panner; split: Split };
+export type CrossFadeAudioEntry   = { kind: 'crossFade';   toneNode: CrossFade };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
@@ -782,6 +802,8 @@ export type AudioNodeEntry =
 	| VolumeAudioEntry
 	| MultibandSplitAudioEntry
 	| SoloAudioEntry
+	| PannerAudioEntry
+	| CrossFadeAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -46,7 +46,7 @@ export type StubKind =
 	| 'midSideCompressor' | 'multibandCompressor'
 	// — Processing —
 	| 'channel' | 'panner3d' | 'crossFade'
-	| 'solo' | 'convolver'
+	| 'convolver'
 	// — Analysis —
 	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
@@ -420,6 +420,12 @@ export type MultibandSplitNodeData = {
 };
 export type MultibandSplitFlowNode = Node<MultibandSplitNodeData, 'multibandSplit'>;
 
+// Whether this instance is soloed is store-driven (daw.ts's soloedNodeId,
+// ADR-0003), not a field here — only one instance can be soloed at a time,
+// so a per-node boolean would just duplicate the store's own truth.
+export type SoloNodeData = { label: string };
+export type SoloFlowNode = Node<SoloNodeData, 'solo'>;
+
 // ─── Analysis node data types ─────────────────────────────────────────────────
 // Analyser-family "tap" nodes: pass audio through unchanged (in-0 → out-0) and
 // separately expose a live-polled readout via engine.ts getters — see
@@ -555,6 +561,7 @@ export type AppNode =
 	| MonoFlowNode
 	| VolumeFlowNode
 	| MultibandSplitFlowNode
+	| SoloFlowNode
 	| FFTFlowNode
 	| MeterFlowNode
 	| DCMeterFlowNode
@@ -710,6 +717,7 @@ export type MergeNodeAudioEntry   = { kind: 'merge';       toneNode: Merge };
 export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
 export type VolumeAudioEntry      = { kind: 'volume';      toneNode: Volume };
 export type MultibandSplitAudioEntry = { kind: 'multibandSplit'; toneNode: MultibandSplit };
+export type SoloAudioEntry        = { kind: 'solo';        toneNode: Solo };
 export type FFTAudioEntry         = { kind: 'fft';         toneNode: FFT };
 export type MeterAudioEntry       = { kind: 'meter';       toneNode: Meter };
 export type DCMeterAudioEntry     = { kind: 'dcMeter';     toneNode: DCMeter };
@@ -773,6 +781,7 @@ export type AudioNodeEntry =
 	| MonoAudioEntry
 	| VolumeAudioEntry
 	| MultibandSplitAudioEntry
+	| SoloAudioEntry
 	| FFTAudioEntry
 	| MeterAudioEntry
 	| DCMeterAudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -42,8 +42,6 @@ export type StubKind =
 	| 'players' | 'userMedia'
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
-	// — Dynamics —
-	| 'multibandCompressor'
 	// — Processing —
 	| 'channel' | 'panner3d'
 	| 'convolver'
@@ -364,6 +362,19 @@ export type MidSideCompressorNodeData = {
 };
 export type MidSideCompressorFlowNode = Node<MidSideCompressorNodeData, 'midSideCompressor'>;
 
+// v1 UI exposes only threshold+ratio per band via CompressorControls' `params`
+// prop (docs/node-roadmap.md: 17 live controls is too heavy) — attack/release/
+// knee still live on each band's data, just defaulted and not user-editable yet.
+export type MultibandCompressorNodeData = {
+	label:         string;
+	lowFrequency:  number;   // Hz, 20–2000, default 250
+	highFrequency: number;   // Hz, 200–20000, default 2000
+	low:           CompressorBandData;
+	mid:           CompressorBandData;
+	high:          CompressorBandData;
+};
+export type MultibandCompressorFlowNode = Node<MultibandCompressorNodeData, 'multibandCompressor'>;
+
 // ─── Processing node data types ───────────────────────────────────────────────
 
 export type BiquadFilterType = 'lowpass' | 'highpass' | 'bandpass' | 'lowshelf' | 'highshelf' | 'notch' | 'allpass' | 'peaking';
@@ -582,6 +593,7 @@ export type AppNode =
 	| GateFlowNode
 	| CompressorFlowNode
 	| MidSideCompressorFlowNode
+	| MultibandCompressorFlowNode
 	| BiquadFilterFlowNode
 	| FilterFlowNode
 	| EQ3FlowNode
@@ -741,6 +753,7 @@ export type LimiterAudioEntry     = { kind: 'limiter';     toneNode: Limiter };
 export type GateAudioEntry        = { kind: 'gate';        toneNode: Gate };
 export type CompressorAudioEntry  = { kind: 'compressor';  toneNode: Compressor };
 export type MidSideCompressorAudioEntry = { kind: 'midSideCompressor'; toneNode: MidSideCompressor };
+export type MultibandCompressorAudioEntry = { kind: 'multibandCompressor'; toneNode: MultibandCompressor };
 export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFilter };
 export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
 export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
@@ -808,6 +821,7 @@ export type AudioNodeEntry =
 	| GateAudioEntry
 	| CompressorAudioEntry
 	| MidSideCompressorAudioEntry
+	| MultibandCompressorAudioEntry
 	| BiquadFilterAudioEntry
 	| FilterAudioEntry
 	| EQ3AudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper, Recorder } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper, Recorder, Channel } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -43,7 +43,6 @@ export type StubKind =
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
 	// — Processing —
-	| 'channel'
 	| 'convolver'
 	// — Analysis —
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
@@ -419,6 +418,19 @@ export type PanVolNodeData = {
 };
 export type PanVolFlowNode = Node<PanVolNodeData, 'panVol'>;
 
+// Channel is PanVol + Solo internally composed (docs/node-roadmap.md) — solo
+// state is deliberately NOT a field here, same reasoning as SoloNodeData:
+// it's store-driven (daw.ts's soloedNodeId, ADR-0003) since Channel and Solo
+// share Tone's own static solo registry. send/receive bus routing is
+// permanently out of scope (docs/adr/0007-channel-send-receive-out-of-scope.md).
+export type ChannelNodeData = {
+	label:  string;
+	volume: number;    // dB, -60–6, default 0
+	pan:    number;    // -1–1, default 0
+	mute:   boolean;   // default false
+};
+export type ChannelFlowNode = Node<ChannelNodeData, 'channel'>;
+
 export type SplitNodeData = { label: string };
 export type SplitFlowNode = Node<SplitNodeData, 'split'>;
 
@@ -630,6 +642,7 @@ export type AppNode =
 	| FilterFlowNode
 	| EQ3FlowNode
 	| PanVolFlowNode
+	| ChannelFlowNode
 	| SplitFlowNode
 	| MergeFlowNode
 	| MonoFlowNode
@@ -793,6 +806,7 @@ export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFil
 export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
 export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
 export type PanVolAudioEntry      = { kind: 'panVol';      toneNode: PanVol };
+export type ChannelAudioEntry     = { kind: 'channel';     toneNode: Channel };
 export type SplitNodeAudioEntry   = { kind: 'split';       toneNode: Split };
 export type MergeNodeAudioEntry   = { kind: 'merge';       toneNode: Merge };
 export type MonoAudioEntry        = { kind: 'mono';        toneNode: Mono };
@@ -864,6 +878,7 @@ export type AudioNodeEntry =
 	| FilterAudioEntry
 	| EQ3AudioEntry
 	| PanVolAudioEntry
+	| ChannelAudioEntry
 	| SplitNodeAudioEntry
 	| MergeNodeAudioEntry
 	| MonoAudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -43,7 +43,7 @@ export type StubKind =
 	| 'synth' | 'monoSynth' | 'polySynth' | 'fmSynth' | 'amSynth' | 'duoSynth'
 	| 'membraneSynth' | 'metalSynth' | 'noiseSynth' | 'pluckSynth' | 'sampler'
 	// — Dynamics —
-	| 'midSideCompressor' | 'multibandCompressor'
+	| 'multibandCompressor'
 	// — Processing —
 	| 'channel' | 'panner3d'
 	| 'convolver'
@@ -341,15 +341,28 @@ export type GateNodeData = {
 };
 export type GateFlowNode = Node<GateNodeData, 'gate'>;
 
-export type CompressorNodeData = {
-	label:     string;
+// Shared by every node with a real Compressor band — standalone Compressor,
+// and MidSideCompressor's/MultibandCompressor's mid/side/low/high children
+// (see CompressorControls, docs/adr/0004-nested-param-panel-layout.md).
+export type CompressorBandData = {
 	threshold: number;   // dB, -100–0, default -24
 	ratio:     number;   // 1–20, default 12
 	attack:    number;   // seconds, 0–1, default 0.003
 	release:   number;   // seconds, 0–1, default 0.25
 	knee:      number;   // dB, 0–40, default 30
 };
+
+export type CompressorNodeData = { label: string } & CompressorBandData;
 export type CompressorFlowNode = Node<CompressorNodeData, 'compressor'>;
+
+// Requires a genuinely stereo input — mid/side encoding is meaningless on
+// mono, flagged in the node's UI (docs/node-roadmap.md).
+export type MidSideCompressorNodeData = {
+	label: string;
+	mid:   CompressorBandData;
+	side:  CompressorBandData;
+};
+export type MidSideCompressorFlowNode = Node<MidSideCompressorNodeData, 'midSideCompressor'>;
 
 // ─── Processing node data types ───────────────────────────────────────────────
 
@@ -568,6 +581,7 @@ export type AppNode =
 	| LimiterFlowNode
 	| GateFlowNode
 	| CompressorFlowNode
+	| MidSideCompressorFlowNode
 	| BiquadFilterFlowNode
 	| FilterFlowNode
 	| EQ3FlowNode
@@ -726,6 +740,7 @@ export type AutoWahAudioEntry         = { kind: 'autoWah';          toneNode: Au
 export type LimiterAudioEntry     = { kind: 'limiter';     toneNode: Limiter };
 export type GateAudioEntry        = { kind: 'gate';        toneNode: Gate };
 export type CompressorAudioEntry  = { kind: 'compressor';  toneNode: Compressor };
+export type MidSideCompressorAudioEntry = { kind: 'midSideCompressor'; toneNode: MidSideCompressor };
 export type BiquadFilterAudioEntry = { kind: 'biquadFilter'; toneNode: BiquadFilter };
 export type FilterAudioEntry      = { kind: 'filter';      toneNode: Filter };
 export type EQ3AudioEntry         = { kind: 'eq3';         toneNode: EQ3 };
@@ -792,6 +807,7 @@ export type AudioNodeEntry =
 	| LimiterAudioEntry
 	| GateAudioEntry
 	| CompressorAudioEntry
+	| MidSideCompressorAudioEntry
 	| BiquadFilterAudioEntry
 	| FilterAudioEntry
 	| EQ3AudioEntry

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -1,5 +1,5 @@
 import type { Node, Edge, BuiltInNode } from '@xyflow/react';
-import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D } from 'tone';
+import type { Player, Gain, Analyser, Oscillator, Merge, Split, Noise, Signal, LFO, FMOscillator, AMOscillator, FatOscillator, PulseOscillator, PWMOscillator, GrainPlayer, UserMedia, Reverb, JCReverb, Freeverb, FeedbackDelay, PingPongDelay, Distortion, Chebyshev, BitCrusher, FrequencyShifter, PitchShift, StereoWidener, Chorus, Phaser, Tremolo, Vibrato, AutoFilter, AutoPanner, AutoWah, Limiter, Gate, BiquadFilter, PanVol, Mono, Volume, FFT, Meter, DCMeter, Waveform, Scale, ScaleExp, Abs, Negate, AudioToGain, GainToAudio, Compressor, Filter, EQ3, MultibandSplit, Follower, Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper } from 'tone';
 
 export type OscType = 'sine' | 'square' | 'triangle' | 'sawtooth';
 
@@ -49,7 +49,7 @@ export type StubKind =
 	| 'recorder'
 	| 'amplitudeEnvelope' | 'frequencyEnvelope'
 	// — Signal —
-	| 'waveShaper' | 'add' | 'multiply' | 'greaterThan'
+	| 'add' | 'multiply' | 'greaterThan'
 	// — Event —
 	| 'loop' | 'sequence' | 'pattern' | 'part' | 'toneEvent';
 
@@ -565,6 +565,18 @@ export type AudioToGainFlowNode = Node<AudioToGainNodeData, 'audioToGain'>;
 export type GainToAudioNodeData = { label: string };
 export type GainToAudioFlowNode = Node<GainToAudioNodeData, 'gainToAudio'>;
 
+// WaveShaper's mapping is a JS function/array, not a slider-able value — the
+// dropdown's value is a preset *name* stored purely for serialization/redraw;
+// selecting one triggers an imperative setMap() rather than a watched param
+// (docs/adr/0005-waveshaper-preset-driven.md).
+export type WaveShaperPreset = 'identity' | 'softClip' | 'hardClip';
+export type WaveShaperNodeData = {
+	label:      string;
+	preset:     WaveShaperPreset;         // default 'identity'
+	oversample: 'none' | '2x' | '4x';     // default 'none'
+};
+export type WaveShaperFlowNode = Node<WaveShaperNodeData, 'waveShaper'>;
+
 export type AppNode =
 	| BuiltInNode
 	| PlayerFlowNode
@@ -633,7 +645,8 @@ export type AppNode =
 	| AbsFlowNode
 	| NegateFlowNode
 	| AudioToGainFlowNode
-	| GainToAudioFlowNode;
+	| GainToAudioFlowNode
+	| WaveShaperFlowNode;
 
 export type AppEdge = Edge;
 
@@ -795,6 +808,7 @@ export type AbsAudioEntry         = { kind: 'abs';         toneNode: Abs };
 export type NegateAudioEntry      = { kind: 'negate';      toneNode: Negate };
 export type AudioToGainAudioEntry = { kind: 'audioToGain'; toneNode: AudioToGain };
 export type GainToAudioAudioEntry = { kind: 'gainToAudio'; toneNode: GainToAudio };
+export type WaveShaperAudioEntry  = { kind: 'waveShaper';  toneNode: WaveShaper };
 
 // Stubs are NOT in the audio registry — they have no Tone.js instances yet.
 
@@ -863,7 +877,8 @@ export type AudioNodeEntry =
 	| AbsAudioEntry
 	| NegateAudioEntry
 	| AudioToGainAudioEntry
-	| GainToAudioAudioEntry;
+	| GainToAudioAudioEntry
+	| WaveShaperAudioEntry;
 
 export type AudioNodeMap = Map<string, AudioNodeEntry>;
 


### PR DESCRIPTION
## Summary
Merges the full Tier 2 + Tier 3 node buildout from `next` into `main`: 21 commits spanning routine Tier 2 nodes (Compressor, Filter, EQ3, MultibandSplit, Analyser, Follower), all 8 Tier 3 nodes (Solo, CrossFade, Panner, MidSideCompressor, MultibandCompressor, Panner3D, WaveShaper, Recorder, Channel), their ADRs (`docs/adr/0001`–`0007`), and post-merge bugfixes found via browser verification (a pre-existing MUI `Select` runtime error, the last remaining `tsc` errors, and a `Recorder.start()` hang for unwired recorders).

`main` has one commit `next` doesn't (`#30`, the oscillator waveform-button 2x2 grid layout) — confirmed via `git merge-tree` that this merges with **zero conflicts** against everything in `next` (no overlapping files).

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — clean
- [x] Full browser verification pass: every node type (89 catalogue entries) added and rendered without console errors; targeted interaction tests on all 8 Tier 3 nodes including cross-instance Solo/Channel dimming, WaveShaper's preset dropdown, and the full Recorder record/pause/stop/download lifecycle
- [x] `git merge-tree` confirms zero conflicts with `main`'s divergent commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)