### PR TITLE
Tint add-node panel buttons by category; swap master-output/signal accent

### DIFF
--- a/src/daw/nodes/shared/nodeColors.ts
+++ b/src/daw/nodes/shared/nodeColors.ts
@@ -23,13 +23,13 @@ export const NODE_COLORS = {
 	source:    PALETTE.blue,      // signal generators: oscillators, noise, player, DC
 	processor: PALETTE.gold,      // signal processors: gain, EQ, filter
 	scene:     PALETTE.purple,    // scene geometry → audio bridge
-	output:    PALETTE.green,     // final destination / master out
+	output:    PALETTE.silver,    // final destination / master out
 	debug:     PALETTE.graphite,  // design sandbox / monitoring utility
 
 	// ── Reserved for future node categories ───────────────────────────────────
 	dynamics:  PALETTE.red,       // compressors, limiters, transient shapers
 	effects:   PALETTE.orange,    // reverb, delay, modulation, time-based FX
-	utility:   PALETTE.silver,    // meters, spectrum analysers, DC blockers
+	utility:   PALETTE.green,     // meters, spectrum analysers, DC blockers, signal math
 } as const;
 
 export type NodeCategory = keyof typeof NODE_COLORS;

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -561,11 +561,11 @@ export function AddNodePanel({
 
 	const itemBtnSx = (catColor: string) => ({
 		...hwBtn(catColor),
-		background: `linear-gradient(to bottom, ${catColor}22 0%, ${catColor}0e 100%)`,
-		border: `1px solid ${catColor}38`,
-		borderTopColor: `${catColor}48`,
-		borderLeftColor: `${catColor}30`,
-		color: `${catColor}d0`,
+		background: `linear-gradient(to bottom, ${catColor}40 0%, ${catColor}1e 100%)`,
+		border: `1px solid ${catColor}60`,
+		borderTopColor: `${catColor}75`,
+		borderLeftColor: `${catColor}55`,
+		color: catColor,
 		width: '100%',
 		px: 1,
 		py: 1,
@@ -576,13 +576,13 @@ export function AddNodePanel({
 		flexDirection: 'column' as const,
 		alignItems: 'flex-start',
 		'&:hover': {
-			background: `linear-gradient(to bottom, ${catColor}38 0%, ${catColor}1c 100%)`,
-			border: `1px solid ${catColor}70`,
-			borderTopColor: `${catColor}80`,
+			background: `linear-gradient(to bottom, ${catColor}5c 0%, ${catColor}30 100%)`,
+			border: `1px solid ${catColor}95`,
+			borderTopColor: `${catColor}aa`,
 			color: catColor,
-			boxShadow: `0 2px 5px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.06), 0 0 8px ${catColor}30`,
+			boxShadow: `0 2px 5px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.06), 0 0 10px ${catColor}45`,
 		},
-		'&:active': { ...hwBtn(catColor)['&:active'], borderColor: `${catColor}60` },
+		'&:active': { ...hwBtn(catColor)['&:active'], borderColor: `${catColor}80` },
 	});
 
 	return (

--- a/src/daw/panels/AddNodePanel.tsx
+++ b/src/daw/panels/AddNodePanel.tsx
@@ -561,6 +561,11 @@ export function AddNodePanel({
 
 	const itemBtnSx = (catColor: string) => ({
 		...hwBtn(catColor),
+		background: `linear-gradient(to bottom, ${catColor}22 0%, ${catColor}0e 100%)`,
+		border: `1px solid ${catColor}38`,
+		borderTopColor: `${catColor}48`,
+		borderLeftColor: `${catColor}30`,
+		color: `${catColor}d0`,
 		width: '100%',
 		px: 1,
 		py: 1,
@@ -570,6 +575,14 @@ export function AddNodePanel({
 		display: 'flex',
 		flexDirection: 'column' as const,
 		alignItems: 'flex-start',
+		'&:hover': {
+			background: `linear-gradient(to bottom, ${catColor}38 0%, ${catColor}1c 100%)`,
+			border: `1px solid ${catColor}70`,
+			borderTopColor: `${catColor}80`,
+			color: catColor,
+			boxShadow: `0 2px 5px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.06), 0 0 8px ${catColor}30`,
+		},
+		'&:active': { ...hwBtn(catColor)['&:active'], borderColor: `${catColor}60` },
 	});
 
 	return (


### PR DESCRIPTION
## Summary
- Add-node panel item buttons now tint their idle/hover state with their category's accent colour instead of a flat grey (`hwBtn`'s base state ignored the passed colour).
- Swapped `NODE_COLORS.output` and `NODE_COLORS.utility` (silver ↔ green) so master output takes the accent previously used by signal/meter nodes and vice versa — propagates automatically to `MasterOutputNode`, its edge colour, and the utility-bucketed categories (Signal, Analysis, Event, meters/analysers).

## Test plan
- [x] `tsc --noEmit` shows no new errors introduced by these files
- [ ] Visually confirm in the running app that add-node panel buttons are tinted per category and master output / signal nodes show swapped colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)