### PR TITLE
Scene Input: multi-source, scene-native geometry composition

### DIFF
--- a/src/daw/panels/InputPanel.tsx
+++ b/src/daw/panels/InputPanel.tsx
@@ -1,9 +1,11 @@
+import { Suspense } from 'react';
 import Box from '@mui/material/Box';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
-import * as THREE from 'three';
 import { useSquareSize } from '../../hooks/useSquareSize';
 import { useSceneToAudio } from '../../scene/useSceneToAudio';
+import { SceneSourcesArrangeScene } from './sceneSources/SceneSourcesArrangeScene';
+import { SceneSourcesOverlay } from './sceneSources/SceneSourcesOverlay';
 
 /**
  * Two canvases rationale: the oscilloscope uses frameloop="demand" (only renders
@@ -12,27 +14,6 @@ import { useSceneToAudio } from '../../scene/useSceneToAudio';
  * WebGL context via <View>, so separate contexts is the correct choice here.
  * Browser WebGL context limits (8–16) are not a concern for two canvases.
  */
-
-const EDGES_GEO = (() => {
-	const geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1));
-	const pos = geo.getAttribute('position');
-	const colors = new Float32Array(pos.count * 3);
-	for (let i = 0; i < pos.count; i++) {
-		colors[i * 3]     = pos.getX(i) + 0.5;
-		colors[i * 3 + 1] = pos.getY(i) + 0.5;
-		colors[i * 3 + 2] = pos.getZ(i) + 0.5;
-	}
-	geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-	return geo;
-})();
-
-function WireframeCube() {
-	return (
-		<lineSegments geometry={EDGES_GEO}>
-			<lineBasicMaterial vertexColors />
-		</lineSegments>
-	);
-}
 
 /** Runs useSceneToAudio inside the Canvas context so useThree() works. */
 function SceneAudioBridge() {
@@ -57,7 +38,7 @@ export function SceneInputPanel() {
 				borderTop:      '1px solid #1a1a1a',
 			}}
 		>
-			<Box sx={{ width: size, height: size, flexShrink: 0, overflow: 'hidden' }}>
+			<Box sx={{ width: size, height: size, flexShrink: 0, overflow: 'hidden', position: 'relative' }}>
 				{size > 0 && (
 					<Canvas
 						orthographic
@@ -82,10 +63,14 @@ export function SceneInputPanel() {
 						}}
 					>
 						<OrbitControls makeDefault />
-						<WireframeCube />
+						{/* Suspense: svgImport/gltfImport sources load async via useLoader (#46, #48) */}
+						<Suspense fallback={null}>
+							<SceneSourcesArrangeScene />
+						</Suspense>
 						<SceneAudioBridge />
 					</Canvas>
 				)}
+				<SceneSourcesOverlay />
 			</Box>
 		</Box>
 	);

--- a/src/daw/panels/sceneSources/SceneSourcesArrangeScene.tsx
+++ b/src/daw/panels/sceneSources/SceneSourcesArrangeScene.tsx
@@ -1,0 +1,136 @@
+/**
+ * Canvas-native source selection + arrangement (issue #43's winning
+ * prototype variant, folded in for real): click a source in the scene to
+ * select it, drei's <TransformControls> gizmo attaches to the selection
+ * (W/E/R mode switch), with a floating duplicate/delete toolbar. Orbit
+ * controls disable while dragging so they don't fight the gizmo.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { useThree } from '@react-three/fiber';
+import { Html, TransformControls } from '@react-three/drei';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useDawStore } from '../../../store/daw';
+import { hwIconBtn, hwToggleSx } from '../../nodes/shared/hwStyles';
+import { NODE_COLORS } from '../../nodes/shared/nodeColors';
+import { sourceRegistry } from '../../../scene/sources/sourceRegistry';
+
+const ACCENT = NODE_COLORS.scene;
+type Mode = 'translate' | 'rotate' | 'scale';
+
+export function SceneSourcesArrangeScene() {
+	const sources          = useDawStore(s => s.sources);
+	const selectedSourceId = useDawStore(s => s.selectedSourceId);
+	const setSelectedSourceId   = useDawStore(s => s.setSelectedSourceId);
+	const updateSourceTransform = useDawStore(s => s.updateSourceTransform);
+	const duplicateSource        = useDawStore(s => s.duplicateSource);
+	const removeSource           = useDawStore(s => s.removeSource);
+
+	const groupRefs    = useRef<Record<string, THREE.Group | null>>({});
+	// Stable per-id ref callbacks — a fresh inline arrow function every render
+	// would make React re-attach the ref (and re-run forceRerender) on every
+	// single render: an infinite loop ("Maximum update depth exceeded").
+	const refCallbacks = useRef<Record<string, (el: THREE.Group | null) => void>>({});
+	const [, forceRerender] = useState(0);
+	const [mode, setMode] = useState<Mode>('translate');
+	const orbit = useThree(s => s.controls) as unknown as { enabled: boolean } | null;
+
+	const getRefCallback = (id: string) => {
+		if (!refCallbacks.current[id]) {
+			refCallbacks.current[id] = (el: THREE.Group | null) => {
+				groupRefs.current[id] = el;
+				if (el) forceRerender(n => n + 1);
+			};
+		}
+		return refCallbacks.current[id];
+	};
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			const tag = (e.target as HTMLElement)?.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+			if (e.key === 'w' || e.key === 'W') setMode('translate');
+			if (e.key === 'e' || e.key === 'E') setMode('rotate');
+			if (e.key === 'r' || e.key === 'R') setMode('scale');
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, []);
+
+	const selectedObj    = selectedSourceId ? groupRefs.current[selectedSourceId] : null;
+	const selectedSource = sources.find(s => s.id === selectedSourceId) ?? null;
+
+	const commitTransform = () => {
+		if (!selectedSourceId) return;
+		const obj = groupRefs.current[selectedSourceId];
+		if (!obj) return;
+		updateSourceTransform(selectedSourceId, {
+			position: [obj.position.x, obj.position.y, obj.position.z],
+			rotation: [obj.rotation.x, obj.rotation.y, obj.rotation.z],
+			scale:    [obj.scale.x, obj.scale.y, obj.scale.z],
+		});
+	};
+
+	return (
+		<group onPointerMissed={() => setSelectedSourceId(null)}>
+			{sources.map((s) => {
+				const Source = sourceRegistry[s.type];
+				return (
+					<group
+						key={s.id}
+						onClick={e => { e.stopPropagation(); setSelectedSourceId(s.id === selectedSourceId ? null : s.id); }}
+					>
+						<Source ref={getRefCallback(s.id)} id={s.id} data={s.data} />
+					</group>
+				);
+			})}
+
+			{selectedObj && selectedSource && (
+				<>
+					<TransformControls
+						object={selectedObj}
+						mode={mode}
+						onMouseDown={() => { if (orbit) orbit.enabled = false; }}
+						onMouseUp={() => { if (orbit) orbit.enabled = true; commitTransform(); }}
+						onObjectChange={commitTransform}
+					/>
+					<Html position={selectedObj.position} center style={{ pointerEvents: 'none' }}>
+						<Box sx={{
+							display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5,
+							transform: 'translateY(-38px)', pointerEvents: 'auto',
+						}}>
+							<ToggleButtonGroup size='small' exclusive value={mode}
+								onChange={(_, v) => v && setMode(v)} sx={hwToggleSx(ACCENT)}>
+								<ToggleButton value='translate'><Tooltip title='Translate (W)'><span>Move</span></Tooltip></ToggleButton>
+								<ToggleButton value='rotate'><Tooltip title='Rotate (E)'><span>Rot</span></Tooltip></ToggleButton>
+								<ToggleButton value='scale'><Tooltip title='Scale (R)'><span>Scale</span></Tooltip></ToggleButton>
+							</ToggleButtonGroup>
+							<Box sx={{
+								display: 'flex', gap: 0.5,
+								bgcolor: 'rgba(20,20,24,0.9)', border: `1px solid ${ACCENT}60`, borderRadius: 1, p: 0.25,
+							}}>
+								<Tooltip title='Duplicate' placement='top'>
+									<IconButton size='small' onClick={() => duplicateSource(selectedSource.id)} sx={{ ...hwIconBtn(ACCENT), p: 0.3 }}>
+										<ContentCopyIcon sx={{ fontSize: 11 }} />
+									</IconButton>
+								</Tooltip>
+								<Tooltip title='Delete' placement='top'>
+									<IconButton size='small' onClick={() => removeSource(selectedSource.id)} sx={{ ...hwIconBtn(ACCENT), p: 0.3 }}>
+										<DeleteIcon sx={{ fontSize: 11 }} />
+									</IconButton>
+								</Tooltip>
+							</Box>
+						</Box>
+					</Html>
+				</>
+			)}
+		</group>
+	);
+}

--- a/src/daw/panels/sceneSources/SceneSourcesOverlay.tsx
+++ b/src/daw/panels/sceneSources/SceneSourcesOverlay.tsx
@@ -1,0 +1,142 @@
+/**
+ * FAB + add-menu + drag-drop import veil — sibling of the R3F <Canvas>
+ * (mounted outside it, in SceneInputPanel). Selection/arrangement itself
+ * lives in SceneSourcesArrangeScene, inside <Canvas>.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import CropSquareIcon from '@mui/icons-material/CropSquare';
+import PanoramaFishEyeIcon from '@mui/icons-material/PanoramaFishEye';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+import type { SvgIconProps } from '@mui/material/SvgIcon';
+import { useDawStore } from '../../../store/daw';
+import { hwDeleteIconBtn } from '../../nodes/shared/hwStyles';
+import { NODE_COLORS } from '../../nodes/shared/nodeColors';
+import { PRIMITIVE_SOURCE_TYPES, SOURCE_TYPE_LABEL } from '../../../scene/sources/sourceRegistry';
+import { fileToDataUri, sourceTypeForFile } from '../../../scene/sources/assetImport';
+import type { GeometrySourceType } from '../../../store/dawTypes';
+
+const COLOR = NODE_COLORS.scene;
+
+const PRIMITIVE_ICON: Record<string, React.ComponentType<SvgIconProps>> = {
+	cube:   CheckBoxOutlineBlankIcon,
+	circle: RadioButtonUncheckedIcon,
+	plane:  CropSquareIcon,
+	sphere: PanoramaFishEyeIcon,
+};
+
+export function SceneSourcesOverlay() {
+	const sources    = useDawStore(s => s.sources);
+	const addSource  = useDawStore(s => s.addSource);
+	const [menuOpen, setMenuOpen] = useState(false);
+	const [dragOver, setDragOver] = useState(false);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const importFile = useCallback(async (file: File) => {
+		const type = sourceTypeForFile(file);
+		if (!type) return;
+		const assetDataUri = await fileToDataUri(file);
+		addSource(type as GeometrySourceType, { assetDataUri, assetName: file.name });
+	}, [addSource]);
+
+	const handleAddPrimitive = useCallback((type: GeometrySourceType) => {
+		addSource(type);
+		setMenuOpen(false);
+	}, [addSource]);
+
+	const handleDragOver  = useCallback((e: React.DragEvent) => { e.preventDefault(); setDragOver(true); }, []);
+	const handleDragLeave = useCallback(() => setDragOver(false), []);
+	const handleDrop = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		setDragOver(false);
+		const file = e.dataTransfer.files[0];
+		if (file) void importFile(file);
+	}, [importFile]);
+
+	const handleFileInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (file) void importFile(file);
+		e.target.value = '';
+	}, [importFile]);
+
+	return (
+		<Box
+			onDragOver={handleDragOver}
+			onDragLeave={handleDragLeave}
+			onDrop={handleDrop}
+			sx={{ position: 'absolute', inset: 0, zIndex: 50, pointerEvents: 'none' }}
+		>
+			<input ref={fileInputRef} type='file' accept='.svg,.glb,.gltf'
+				style={{ display: 'none' }} onChange={handleFileInputChange} />
+
+			{dragOver && (
+				<Box sx={{
+					position: 'absolute', inset: 0, pointerEvents: 'none',
+					bgcolor: `${COLOR}14`, border: `2px dashed ${COLOR}80`,
+					display: 'flex', alignItems: 'center', justifyContent: 'center',
+				}}>
+					<Typography sx={{ fontSize: 12, color: COLOR, fontWeight: 600 }}>Drop to import (SVG / glTF)</Typography>
+				</Box>
+			)}
+
+			<Typography sx={{
+				position: 'absolute', top: 8, left: 8, fontSize: 8.5, color: 'text.disabled', letterSpacing: 0.4,
+			}}>
+				{sources.length} source{sources.length === 1 ? '' : 's'} — click an object to select
+			</Typography>
+
+			<Box sx={{ position: 'absolute', bottom: 12, right: 12, pointerEvents: 'auto' }}>
+				{menuOpen && (
+					<Box sx={{
+						position: 'absolute', bottom: '100%', right: 0, mb: 1,
+						bgcolor: 'rgba(20,20,24,0.95)', border: `1px solid ${COLOR}40`, borderRadius: 1,
+						p: 0.5, display: 'flex', flexDirection: 'column', gap: 0.25, width: 150,
+					}}>
+						{PRIMITIVE_SOURCE_TYPES.map((t) => {
+							const Icon = PRIMITIVE_ICON[t];
+							return (
+								<Box key={t} component='button' onClick={() => handleAddPrimitive(t)}
+									sx={{
+										display: 'flex', alignItems: 'center', gap: 0.75,
+										background: 'none', border: 'none', color: 'text.secondary', cursor: 'pointer',
+										fontSize: 10, p: 0.5, borderRadius: 0.5, textAlign: 'left',
+										'&:hover': { color: COLOR, background: `${COLOR}14` },
+									}}>
+									<Icon sx={{ fontSize: 13 }} />
+									{SOURCE_TYPE_LABEL[t]}
+								</Box>
+							);
+						})}
+						<Box component='button' onClick={() => { fileInputRef.current?.click(); setMenuOpen(false); }}
+							sx={{
+								display: 'flex', alignItems: 'center', gap: 0.75,
+								background: 'none', border: 'none', color: 'text.secondary', cursor: 'pointer',
+								fontSize: 10, p: 0.5, borderRadius: 0.5, textAlign: 'left',
+								borderTop: `1px solid ${COLOR}20`, mt: 0.25, pt: 0.75,
+								'&:hover': { color: COLOR, background: `${COLOR}14` },
+							}}>
+							<FileUploadIcon sx={{ fontSize: 13 }} />
+							Import file…
+						</Box>
+					</Box>
+				)}
+				<IconButton onClick={() => setMenuOpen(v => !v)}
+					sx={{
+						...hwDeleteIconBtn(COLOR), width: 34, height: 34,
+						color: menuOpen ? '#000' : COLOR,
+						background: menuOpen ? `linear-gradient(to bottom, ${COLOR}ee, ${COLOR}cc)` : undefined,
+						transform: menuOpen ? 'rotate(45deg)' : 'none',
+						transition: 'transform 120ms ease',
+					}}>
+					<AddIcon />
+				</IconButton>
+			</Box>
+		</Box>
+	);
+}

--- a/src/scene/sources/CircleSource.tsx
+++ b/src/scene/sources/CircleSource.tsx
@@ -1,0 +1,35 @@
+import { forwardRef, useMemo } from 'react';
+import * as THREE from 'three';
+import type { SourceComponentProps } from './sourceRegistry';
+
+/**
+ * The `circle` type — built directly as a THREE.LineLoop, not via
+ * EdgesGeometry(CircleGeometry) (which would triangulate and produce noisy
+ * radial spokes for no benefit). A perfectly smooth curve at zero extra
+ * cost — the "prefer direct construction" principle from issue #45.
+ */
+
+const SEGMENTS = 48;
+const RADIUS   = 0.4;
+
+export const CircleSource = forwardRef<THREE.Group, SourceComponentProps>(({ data }, ref) => {
+	const { position, rotation, scale } = data.transform;
+
+	const geometry = useMemo(() => {
+		const points: THREE.Vector3[] = [];
+		for (let i = 0; i < SEGMENTS; i++) {
+			const theta = (i / SEGMENTS) * Math.PI * 2;
+			points.push(new THREE.Vector3(Math.cos(theta) * RADIUS, Math.sin(theta) * RADIUS, 0));
+		}
+		return new THREE.BufferGeometry().setFromPoints(points);
+	}, []);
+
+	return (
+		<group ref={ref} position={position} rotation={rotation} scale={scale}>
+			<lineLoop geometry={geometry}>
+				<lineBasicMaterial color='#ffffff' />
+			</lineLoop>
+		</group>
+	);
+});
+CircleSource.displayName = 'CircleSource';

--- a/src/scene/sources/CubeSource.tsx
+++ b/src/scene/sources/CubeSource.tsx
@@ -1,0 +1,34 @@
+import { forwardRef } from 'react';
+import * as THREE from 'three';
+import type { SourceComponentProps } from './sourceRegistry';
+
+/**
+ * The `cube` type — generalized from the app's original hardcoded shape
+ * (Wayfinder issue #40, #45). Geometry construction is unchanged: per-vertex
+ * color mapped from box-local position, exactly as before.
+ */
+
+const EDGES_GEO = (() => {
+	const geo = new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1));
+	const pos = geo.getAttribute('position');
+	const colors = new Float32Array(pos.count * 3);
+	for (let i = 0; i < pos.count; i++) {
+		colors[i * 3]     = pos.getX(i) + 0.5;
+		colors[i * 3 + 1] = pos.getY(i) + 0.5;
+		colors[i * 3 + 2] = pos.getZ(i) + 0.5;
+	}
+	geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+	return geo;
+})();
+
+export const CubeSource = forwardRef<THREE.Group, SourceComponentProps>(({ data }, ref) => {
+	const { position, rotation, scale } = data.transform;
+	return (
+		<group ref={ref} position={position} rotation={rotation} scale={scale}>
+			<lineSegments geometry={EDGES_GEO}>
+				<lineBasicMaterial vertexColors />
+			</lineSegments>
+		</group>
+	);
+});
+CubeSource.displayName = 'CubeSource';

--- a/src/scene/sources/GltfImportSource.tsx
+++ b/src/scene/sources/GltfImportSource.tsx
@@ -1,0 +1,56 @@
+import { forwardRef, useMemo } from 'react';
+import * as THREE from 'three';
+import { useLoader } from '@react-three/fiber';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import type { SourceComponentProps } from './sourceRegistry';
+
+/**
+ * The `gltfImport` type (issue #48). `useLoader` + Suspense keeps this
+ * component synchronous-looking despite async parsing — the caller
+ * (SceneInputPanel) wraps source rendering in <Suspense>.
+ *
+ * Native Line/LineSegments/LineLoop/Points pass through untouched (glTF's
+ * LINES/LINE_STRIP/LINE_LOOP/POINTS primitive modes already produce exactly
+ * these types — GLTFLoader.js maps them directly, confirmed in the #47
+ * research). Any Mesh (the common triangle-mode case) is replaced in-place
+ * with an EdgesGeometry-derived LineSegments at the same local transform,
+ * preserving the scene's nested hierarchy — not flattened to one group,
+ * since a flattened copy would lose accumulated parent transforms below
+ * the root.
+ */
+
+const EDGES_THRESHOLD = 1; // degrees — three.js's EdgesGeometry default, fixed per #45
+
+export const GltfImportSource = forwardRef<THREE.Group, SourceComponentProps>(({ data }, ref) => {
+	const { position, rotation, scale } = data.transform;
+	const gltf = useLoader(GLTFLoader, data.assetDataUri ?? '');
+
+	const walked = useMemo(() => {
+		const clone = gltf.scene.clone(true);
+		const meshes: { mesh: THREE.Mesh; parent: THREE.Object3D }[] = [];
+		clone.traverse((obj) => {
+			if (obj instanceof THREE.Mesh && obj.parent) {
+				meshes.push({ mesh: obj, parent: obj.parent });
+			}
+		});
+		for (const { mesh, parent } of meshes) {
+			const edges = new THREE.EdgesGeometry(mesh.geometry, EDGES_THRESHOLD);
+			const srcMat = Array.isArray(mesh.material) ? mesh.material[0] : mesh.material;
+			const color = (srcMat as THREE.MeshStandardMaterial)?.color?.clone() ?? new THREE.Color('#ffffff');
+			const line = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({ color }));
+			line.position.copy(mesh.position);
+			line.rotation.copy(mesh.rotation);
+			line.scale.copy(mesh.scale);
+			parent.remove(mesh);
+			parent.add(line);
+		}
+		return clone;
+	}, [gltf]);
+
+	return (
+		<group ref={ref} position={position} rotation={rotation} scale={scale}>
+			<primitive object={walked} />
+		</group>
+	);
+});
+GltfImportSource.displayName = 'GltfImportSource';

--- a/src/scene/sources/PlaneSource.tsx
+++ b/src/scene/sources/PlaneSource.tsx
@@ -1,0 +1,22 @@
+import { forwardRef, useMemo } from 'react';
+import * as THREE from 'three';
+import type { SourceComponentProps } from './sourceRegistry';
+
+/**
+ * The `plane` type — EdgesGeometry(PlaneGeometry) is a clean 4-edge outline
+ * (flat, no curved surfaces to produce noise), per issue #45.
+ */
+
+export const PlaneSource = forwardRef<THREE.Group, SourceComponentProps>(({ data }, ref) => {
+	const { position, rotation, scale } = data.transform;
+	const geometry = useMemo(() => new THREE.EdgesGeometry(new THREE.PlaneGeometry(0.7, 0.7)), []);
+
+	return (
+		<group ref={ref} position={position} rotation={rotation} scale={scale}>
+			<lineSegments geometry={geometry}>
+				<lineBasicMaterial color='#ffffff' />
+			</lineSegments>
+		</group>
+	);
+});
+PlaneSource.displayName = 'PlaneSource';

--- a/src/scene/sources/SphereSource.tsx
+++ b/src/scene/sources/SphereSource.tsx
@@ -1,0 +1,24 @@
+import { forwardRef, useMemo } from 'react';
+import * as THREE from 'three';
+import type { SourceComponentProps } from './sourceRegistry';
+
+/**
+ * The `sphere` type — the one v1 primitive with no analytic line form
+ * (issue #45). EdgesGeometry(IcosahedronGeometry) deliberately low-poly
+ * (not a smooth high-poly UV sphere) to keep edge count and visual noise
+ * down — the closest we get to "clean" for a curved surface.
+ */
+
+export const SphereSource = forwardRef<THREE.Group, SourceComponentProps>(({ data }, ref) => {
+	const { position, rotation, scale } = data.transform;
+	const geometry = useMemo(() => new THREE.EdgesGeometry(new THREE.IcosahedronGeometry(0.4, 1)), []);
+
+	return (
+		<group ref={ref} position={position} rotation={rotation} scale={scale}>
+			<lineSegments geometry={geometry}>
+				<lineBasicMaterial color='#ffffff' />
+			</lineSegments>
+		</group>
+	);
+});
+SphereSource.displayName = 'SphereSource';

--- a/src/scene/sources/SvgImportSource.tsx
+++ b/src/scene/sources/SvgImportSource.tsx
@@ -1,0 +1,99 @@
+import { forwardRef, useMemo } from 'react';
+import * as THREE from 'three';
+import { useLoader } from '@react-three/fiber';
+import { SVGLoader } from 'three/examples/jsm/loaders/SVGLoader.js';
+import type { SourceComponentProps } from './sourceRegistry';
+
+/**
+ * The `svgImport` type (issue #46). `SVGLoader.parse()`'s subpaths already
+ * flatten curves into polylines via `getPoints()` — direct line/loop
+ * construction, no triangulation or EdgesGeometry fallback needed at all
+ * (better than the glTF triangle-mode case).
+ *
+ * Fill vs. stroke only affects color, never geometry — every path becomes a
+ * traced outline regardless of SVG fill/stroke styling. `subPath.autoClose`
+ * (set when the path data ends in Z/z) decides LineLoop vs. Line.
+ */
+
+function isUsableColor(c?: string): c is string {
+	if (!c) return false;
+	const normalized = c.trim().toLowerCase();
+	// SVG's own default fill ('#000') would otherwise render invisible
+	// against reactoscope's black scene background — treat "no meaningful
+	// color specified" and "literally black" the same way.
+	return normalized !== 'none' && normalized !== '#000' && normalized !== '#000000' && normalized !== 'black';
+}
+
+type SvgParseResult = ReturnType<InstanceType<typeof SVGLoader>['parse']>;
+type SvgPathStyle = { fill?: string; stroke?: string };
+
+function getNormalization(xml: XMLDocument, paths: SvgParseResult['paths']) {
+	const svgRoot = xml.documentElement;
+	const viewBox = svgRoot?.getAttribute('viewBox');
+	let minX = 0, minY = 0, width = 0, height = 0;
+
+	if (viewBox) {
+		const parts = viewBox.trim().split(/[\s,]+/).map(Number);
+		[minX, minY, width, height] = parts;
+	} else {
+		const w = parseFloat(svgRoot?.getAttribute('width') ?? '');
+		const h = parseFloat(svgRoot?.getAttribute('height') ?? '');
+		if (!Number.isNaN(w) && !Number.isNaN(h)) {
+			width = w; height = h;
+		} else {
+			const box = new THREE.Box2();
+			for (const shapePath of paths) {
+				for (const subPath of shapePath.subPaths) {
+					for (const pt of subPath.getPoints()) box.expandByPoint(pt);
+				}
+			}
+			if (!box.isEmpty()) {
+				minX = box.min.x; minY = box.min.y;
+				width = box.max.x - box.min.x; height = box.max.y - box.min.y;
+			}
+		}
+	}
+
+	const maxDim = Math.max(width, height) || 1;
+	return { scale: 1 / maxDim, centerX: minX + width / 2, centerY: minY + height / 2 };
+}
+
+export const SvgImportSource = forwardRef<THREE.Group, SourceComponentProps>(({ data }, ref) => {
+	const { position, rotation, scale } = data.transform;
+	const parsed = useLoader(SVGLoader, data.assetDataUri ?? '');
+
+	const walked = useMemo(() => {
+		const group = new THREE.Group();
+		const { scale: norm, centerX, centerY } = getNormalization(parsed.xml, parsed.paths);
+
+		for (const shapePath of parsed.paths) {
+			const style = shapePath.userData?.style as SvgPathStyle | undefined;
+			const colorHex = isUsableColor(style?.stroke) ? style.stroke : (isUsableColor(style?.fill) ? style.fill : undefined);
+			const color = colorHex ? new THREE.Color(colorHex) : new THREE.Color('#ffffff');
+
+			for (const subPath of shapePath.subPaths) {
+				const points2d = subPath.getPoints();
+				if (points2d.length < 2) continue;
+				// Flatten to z=0; flip Y (SVG is Y-down, reactoscope is Y-up);
+				// normalize+center via the viewBox (or computed bbox fallback).
+				const points3d = points2d.map(p =>
+					new THREE.Vector3((p.x - centerX) * norm, -(p.y - centerY) * norm, 0),
+				);
+				const geometry = new THREE.BufferGeometry().setFromPoints(points3d);
+				const material = new THREE.LineBasicMaterial({ color });
+				group.add(subPath.autoClose
+					? new THREE.LineLoop(geometry, material)
+					: new THREE.Line(geometry, material));
+			}
+		}
+
+		return group;
+	}, [parsed]);
+
+	return (
+		<group ref={ref} position={position} rotation={rotation} scale={scale}>
+			<primitive object={walked} />
+		</group>
+	);
+});
+SvgImportSource.displayName = 'SvgImportSource';

--- a/src/scene/sources/assetImport.ts
+++ b/src/scene/sources/assetImport.ts
@@ -1,0 +1,37 @@
+import type { GeometrySourceType } from '../../store/dawTypes';
+
+/** Which geometry-source type an imported file becomes, by extension. */
+export function sourceTypeForFile(file: File): GeometrySourceType | null {
+	const name = file.name.toLowerCase();
+	if (name.endsWith('.svg')) return 'svgImport';
+	if (name.endsWith('.glb') || name.endsWith('.gltf')) return 'gltfImport';
+	return null;
+}
+
+function mimeForFile(file: File): string {
+	const name = file.name.toLowerCase();
+	if (name.endsWith('.svg'))  return 'image/svg+xml';
+	if (name.endsWith('.glb'))  return 'model/gltf-binary';
+	if (name.endsWith('.gltf')) return 'model/gltf+json';
+	return file.type || 'application/octet-stream';
+}
+
+/** Chunked to avoid a call-stack overflow from spreading a huge Uint8Array. */
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+	const bytes = new Uint8Array(buf);
+	let binary = '';
+	const chunkSize = 0x8000;
+	for (let i = 0; i < bytes.length; i += chunkSize) {
+		binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+	}
+	return btoa(binary);
+}
+
+/**
+ * A single self-describing base64 data URI (issue #44) — works uniformly for
+ * binary (.glb) and text (SVG) assets, keeps Patch a self-contained JSON file.
+ */
+export async function fileToDataUri(file: File): Promise<string> {
+	const buffer = await file.arrayBuffer();
+	return `data:${mimeForFile(file)};base64,${arrayBufferToBase64(buffer)}`;
+}

--- a/src/scene/sources/sourceRegistry.tsx
+++ b/src/scene/sources/sourceRegistry.tsx
@@ -1,0 +1,54 @@
+/**
+ * Scene geometry source registry — mirrors `nodeRegistry.ts`'s type→handler
+ * split (issue #42), but the "handler" is a plain React component instead of
+ * an imperative create/dispose pair: R3F's own mount/unmount already gives
+ * lifecycle management for free.
+ */
+
+import type { ForwardRefExoticComponent, RefAttributes } from 'react';
+import type { Group } from 'three';
+import type { GeometrySourceData, GeometrySourceType } from '../../store/dawTypes';
+import { CubeSource } from './CubeSource';
+import { CircleSource } from './CircleSource';
+import { PlaneSource } from './PlaneSource';
+import { SphereSource } from './SphereSource';
+import { SvgImportSource } from './SvgImportSource';
+import { GltfImportSource } from './GltfImportSource';
+
+export type SourceComponentProps = { id: string; data: GeometrySourceData };
+// forwardRef'd to the source's own outer <group> (not a second wrapper group)
+// so the arrange-scene UI's TransformControls gizmo can attach to the exact
+// same object that `data.transform` drives — a separate wrapper would double
+// up position during a drag (see SceneSourcesArrangeScene.tsx).
+export type SourceComponent = ForwardRefExoticComponent<SourceComponentProps & RefAttributes<Group>>;
+
+export const sourceRegistry: Record<GeometrySourceType, SourceComponent> = {
+	cube:       CubeSource,
+	circle:     CircleSource,
+	plane:      PlaneSource,
+	sphere:     SphereSource,
+	svgImport:  SvgImportSource,
+	gltfImport: GltfImportSource,
+};
+
+export const SOURCE_TYPE_LABEL: Record<GeometrySourceType, string> = {
+	cube:       'Cube',
+	circle:     'Circle',
+	plane:      'Plane',
+	sphere:     'Sphere',
+	svgImport:  'Import SVG…',
+	gltfImport: 'Import glTF…',
+};
+
+/** Primitive types offered directly in the add-menu (importers go through a file picker). */
+export const PRIMITIVE_SOURCE_TYPES: GeometrySourceType[] = ['cube', 'circle', 'plane', 'sphere'];
+
+export function defaultSourceData(): GeometrySourceData {
+	return {
+		transform: {
+			position: [0, 0, 0],
+			rotation: [0, 0, 0],
+			scale:    [1, 1, 1],
+		},
+	};
+}

--- a/src/store/daw.ts
+++ b/src/store/daw.ts
@@ -34,6 +34,10 @@ import type {
 	StubKind,
 	PatchFile,
 	MasterOutputNodeData,
+	GeometrySourceEntry,
+	GeometrySourceType,
+	GeometrySourceData,
+	GeometrySourceTransform,
 } from './dawTypes';
 
 export { MASTER_NODE_ID, SCENE_INPUT_ID };
@@ -146,6 +150,15 @@ const initialEdges: AppEdge[] = [
 	{ id: 'e-scene-a', source: SCENE_INPUT_ID, sourceHandle: 'out-5', target: MASTER_NODE_ID, targetHandle: 'in-5', animated: false, type: 'deletable', style: { stroke: NODE_COLORS.scene } },
 ];
 
+function identityTransform(): GeometrySourceTransform {
+	return { position: [0, 0, 0], rotation: [0, 0, 0], scale: [1, 1, 1] };
+}
+
+// Preserves the app's original hardcoded-cube behaviour as the starting scene.
+const initialSources: GeometrySourceEntry[] = [
+	{ id: 'source-cube-default', type: 'cube', data: { transform: identityTransform() } },
+];
+
 // ─── Zustand store ────────────────────────────────────────────────────────────
 
 type DawState = {
@@ -156,6 +169,17 @@ type DawState = {
 	sceneRunning:   boolean;
 	playingNodes:   Set<string>;
 	soloedNodeId:   string | null;
+
+	// Scene geometry sources — scene-native, kept separate from the node graph
+	// (Wayfinder map #39). See src/scene/sources/sourceRegistry.tsx for the
+	// type→component registry that renders these.
+	sources:                 GeometrySourceEntry[];
+	selectedSourceId:        string | null;
+	addSource:               (type: GeometrySourceType, dataOverride?: Partial<GeometrySourceData>) => string;
+	removeSource:            (id: string) => void;
+	duplicateSource:         (id: string) => string;
+	updateSourceTransform:   (id: string, transform: Partial<GeometrySourceTransform>) => void;
+	setSelectedSourceId:     (id: string | null) => void;
 
 	onNodesChange:     OnNodesChange<AppNode>;
 	onEdgesChange:     OnEdgesChange<AppEdge>;
@@ -189,6 +213,51 @@ export const useDawStore = create<DawState>((set, get) => ({
 	sceneRunning:   false,
 	playingNodes:   new Set<string>(),
 	soloedNodeId:   null,
+
+	sources:          initialSources,
+	selectedSourceId: null,
+
+	addSource: (type, dataOverride) => {
+		const id = `${type}-${Date.now()}`;
+		const data: GeometrySourceData = { transform: identityTransform(), ...dataOverride };
+		set(state => ({ sources: [...state.sources, { id, type, data }], selectedSourceId: id }));
+		return id;
+	},
+
+	removeSource: (id) => {
+		set(state => ({
+			sources:          state.sources.filter(s => s.id !== id),
+			selectedSourceId: state.selectedSourceId === id ? null : state.selectedSourceId,
+		}));
+	},
+
+	duplicateSource: (id) => {
+		const src = get().sources.find(s => s.id === id);
+		if (!src) return '';
+		const newId = `${src.type}-${Date.now()}`;
+		const offsetPosition: [number, number, number] = [
+			src.data.transform.position[0] + 0.15,
+			src.data.transform.position[1],
+			src.data.transform.position[2],
+		];
+		const copy: GeometrySourceEntry = {
+			id:   newId,
+			type: src.type,
+			data: { ...src.data, transform: { ...src.data.transform, position: offsetPosition } },
+		};
+		set(state => ({ sources: [...state.sources, copy], selectedSourceId: newId }));
+		return newId;
+	},
+
+	updateSourceTransform: (id, transform) => {
+		set(state => ({
+			sources: state.sources.map(s =>
+				s.id === id ? { ...s, data: { ...s.data, transform: { ...s.data.transform, ...transform } } } : s,
+			),
+		}));
+	},
+
+	setSelectedSourceId: (id) => set({ selectedSourceId: id }),
 
 	setNodePlaying: (id, playing) => set(state => {
 		const next = new Set(state.playingNodes);
@@ -427,14 +496,19 @@ export const useDawStore = create<DawState>((set, get) => ({
 		);
 
 		set({
-			nodes:          restoredNodes,
-			edges:          patch.edges,
-			edgePathType:   patch.edgePathType,
-			audioVersion:   get().audioVersion + 1,
-			sceneRunning:   false,
-			selectedNodeId: null,
-			playingNodes:   new Set<string>(),
-			soloedNodeId:   null,
+			nodes:            restoredNodes,
+			edges:            patch.edges,
+			edgePathType:     patch.edgePathType,
+			// Old saved patches predate this field — fall back to the default
+			// cube so their visual behaviour (a cube was always shown, then
+			// hardcoded) doesn't silently regress to an empty scene.
+			sources:          patch.sources ?? initialSources,
+			selectedSourceId: null,
+			audioVersion:     get().audioVersion + 1,
+			sceneRunning:     false,
+			selectedNodeId:   null,
+			playingNodes:     new Set<string>(),
+			soloedNodeId:     null,
 		});
 	},
 
@@ -455,8 +529,8 @@ export function isMasterMultichannel(edges: AppEdge[]): boolean {
 // ─── Patch export helpers ─────────────────────────────────────────────────────
 
 export function exportPatch(name: string): PatchFile {
-	const { nodes, edges, edgePathType } = useDawStore.getState();
-	return { version: 1, savedAt: new Date().toISOString(), name, nodes, edges, edgePathType };
+	const { nodes, edges, edgePathType, sources } = useDawStore.getState();
+	return { version: 1, savedAt: new Date().toISOString(), name, nodes, edges, edgePathType, sources };
 }
 
 export function downloadPatch(patch: PatchFile, filenameStem?: string): void {

--- a/src/store/dawTypes.ts
+++ b/src/store/dawTypes.ts
@@ -670,6 +670,35 @@ export type AppNode =
 
 export type AppEdge = Edge;
 
+// ─── Scene geometry sources ────────────────────────────────────────────────────
+// Scene-native (not graph nodes — Wayfinder map #39, issue #40): a `sources`
+// list separate from the node graph, mirroring the audio-node store-entry /
+// runtime-handler split (issue #42) but with a plain React component as the
+// "handler" instead of an imperative create/dispose pair, since R3F's own
+// mount/unmount already gives lifecycle management for free.
+
+export type GeometrySourceType = 'cube' | 'circle' | 'plane' | 'sphere' | 'svgImport' | 'gltfImport';
+
+export type GeometrySourceTransform = {
+	position: [number, number, number];
+	rotation: [number, number, number];
+	scale:    [number, number, number];
+};
+
+export type GeometrySourceData = {
+	transform:    GeometrySourceTransform;
+	// svgImport / gltfImport only — the imported file's bytes as a self-describing
+	// data URI (issue #44), e.g. 'data:model/gltf-binary;base64,...'.
+	assetDataUri?: string;
+	assetName?:    string; // display name, e.g. "satellite.glb"
+};
+
+export type GeometrySourceEntry = {
+	id:   string;
+	type: GeometrySourceType;
+	data: GeometrySourceData;
+};
+
 // ─── Audio node registry entries ─────────────────────────────────────────────
 
 export type PlayerAudioEntry = {
@@ -915,4 +944,5 @@ export type PatchFile = {
 	nodes:        AppNode[];
 	edges:        AppEdge[];
 	edgePathType: 'bezier' | 'straight' | 'step' | 'smoothstep';
+	sources:      GeometrySourceEntry[];
 };


### PR DESCRIPTION
## Summary

Implements the full spec from the Wayfinder map [Scene Input: multi-source, scene-native geometry composition](https://github.com/vniow/reactoscope/issues/39) — replaces `SceneInputPanel`'s single hardcoded wireframe cube with a `sources` store array supporting multiple simultaneous, scene-native geometry sources.

- **Store**: `sources: GeometrySourceEntry[]` in `DawState`, separate from the node graph — `addSource`/`removeSource`/`duplicateSource`/`updateSourceTransform`. Round-trips through Patch save/load (#44), with a backward-compat fallback for patches saved before this feature.
- **Primitives**: Cube (generalized from the original hardcoded shape, unchanged geometry), Circle, Plane, Sphere. Direct line/loop construction preferred over `EdgesGeometry` wherever a shape has a native line form (#45) — a circle is a true `LineLoop`, not a triangulated-then-extracted outline.
- **Import**: glTF (`GLTFLoader`) and SVG (`SVGLoader`), both loaded async via `useLoader`+Suspense. glTF preserves nested scene hierarchy when converting triangle meshes to edges (#48); SVG uses direct polyline construction via each subpath's `getPoints()`, with viewBox-based normalization and Y-flip (#46).
- **UI**: canvas-native click-to-select + drei's `TransformControls` gizmo (translate/rotate/scale, W/E/R), a floating duplicate/delete toolbar, and a FAB add-menu with drag-drop file import — the winner of two rounds of live prototyping against the actual app (#43).

## Test plan

- [x] `tsc --noEmit` clean (`noUnusedLocals`/`noUnusedParameters` on)
- [x] Verified live in the browser: add/duplicate/delete each primitive type, gizmo drag commits back to the store, Patch save → mutate scene → load restores the saved `sources` exactly, SVG import runs the full parse→normalize→render pipeline with no console errors
- [ ] Manual: import a real `.glb` file (only synthetic SVG was tested end-to-end this session)
- [ ] Manual: verify glTF import on a multi-mesh/nested-hierarchy model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L29SNVJeYbxCHyBwz9a3ex